### PR TITLE
Display job details in full-width row

### DIFF
--- a/src/components/JobsPanel.jsx
+++ b/src/components/JobsPanel.jsx
@@ -198,22 +198,28 @@ export default function JobsPanel({ db, setDb, companyId }){
               </thead>
               <tbody>
                 {shown.map(j => (
-                  <tr key={j.id}>
-                    <td style={{fontWeight:600}}>{j.orderNumber}</td>
-                    <td>{j.serialNumber}</td>
-                    <td><span className="badge">{JOB_TYPES.find(t=>t.value===j.jobType)?.label || j.jobType}</span></td>
-                    <td>{j.dueDate ? <span className={isOverdue(j.dueDate) && !["zakonczone","odeslane"].includes(j.status) ? "danger-text":""}>{new Date(j.dueDate).toLocaleDateString()}</span> : "—"}</td>
-                    <td>{DEFAULT_STATUSES.find(s=>s.value===j.status)?.label || j.status}</td>
-                    <td>{new Date(j.createdAt).toLocaleString()}</td>
-                    <td>
-                      <div className="row-actions">
-                        <button className="btn" onClick={()=>edit(j)}>Edytuj</button>
-                        <button className="btn" onClick={()=>openUsage(j)}>Części</button>
-                        <button className="btn danger" onClick={()=>del(j.id)}>Usuń</button>
-                      </div>
-                      <JobDetails job={j} total={totalShip(j)} />
-                    </td>
-                  </tr>
+                  <React.Fragment key={j.id}>
+                    <tr>
+                      <td style={{fontWeight:600}}>{j.orderNumber}</td>
+                      <td>{j.serialNumber}</td>
+                      <td><span className="badge">{JOB_TYPES.find(t=>t.value===j.jobType)?.label || j.jobType}</span></td>
+                      <td>{j.dueDate ? <span className={isOverdue(j.dueDate) && !["zakonczone","odeslane"].includes(j.status) ? "danger-text":""}>{new Date(j.dueDate).toLocaleDateString()}</span> : "—"}</td>
+                      <td>{DEFAULT_STATUSES.find(s=>s.value===j.status)?.label || j.status}</td>
+                      <td>{new Date(j.createdAt).toLocaleString()}</td>
+                      <td>
+                        <div className="row-actions">
+                          <button className="btn" onClick={()=>edit(j)}>Edytuj</button>
+                          <button className="btn" onClick={()=>openUsage(j)}>Części</button>
+                          <button className="btn danger" onClick={()=>del(j.id)}>Usuń</button>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td colSpan={7}>
+                        <JobDetails job={j} total={totalShip(j)} />
+                      </td>
+                    </tr>
+                  </React.Fragment>
                 ))}
                 {shown.length===0 && <tr><td colSpan="7" style={{textAlign:'center', padding:'16px', color:'#64748b'}}>Brak zleceń spełniających kryteria</td></tr>}
               </tbody>

--- a/src/styles.css
+++ b/src/styles.css
@@ -28,6 +28,6 @@ table { width:100%; border-collapse: collapse; font-size: 14px; }
 th, td { border-bottom:1px solid #e2e8f0; padding: 8px 12px; text-align: left; vertical-align: top; }
 th { font-weight: 500; color:#64748b; }
 .badge { display:inline-flex; align-items:center; padding:2px 8px; border-radius:999px; font-size:12px; background:#e2e8f0; color:#334155; }
-.row-actions { display:flex; flex-wrap:wrap; gap:6px; margin-bottom:6px; }
+.row-actions { display:flex; flex-wrap:wrap; gap:6px; }
 .danger-text { color:#b91c1c; }
 .dim { color:#64748b; }


### PR DESCRIPTION
## Summary
- Show JobDetails component in its own table row spanning the full width of the jobs table
- Keep action buttons in their cell while adjusting table layout
- Remove bottom margin from `.row-actions` for cleaner spacing

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c642dfd1c832fb9634e3ae4c2c3a1