### PR TITLE
Remove USA return tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/components/InventoryPanel.jsx
+++ b/src/components/InventoryPanel.jsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react'
 import { todayISO, uid } from '../utils'
 
 export default function InventoryPanel({ db, setDb, companyId }){
-  const [form, setForm] = useState({ sku:"", name:"", qty:1, location:"", minQty:0, toReturnUSA:false })
+  const [form, setForm] = useState({ sku:"", name:"", qty:1, location:"", minQty:0 })
   const [search, setSearch] = useState("")
   const items = useMemo(()=> db.inventory.filter(i=>i.companyId===companyId), [db, companyId])
   const shown = useMemo(()=>{
@@ -16,9 +16,9 @@ export default function InventoryPanel({ db, setDb, companyId }){
 
   function addItem(){
     if(!form.name.trim()) return alert("Podaj nazwę pozycji")
-    const it = { id: uid(), companyId, sku: form.sku.trim(), name: form.name.trim(), qty: Math.max(0, Number(form.qty)||0), location: form.location.trim(), minQty: Math.max(0, Number(form.minQty)||0), toReturnUSA: !!form.toReturnUSA, createdAt: todayISO() }
+    const it = { id: uid(), companyId, sku: form.sku.trim(), name: form.name.trim(), qty: Math.max(0, Number(form.qty)||0), location: form.location.trim(), minQty: Math.max(0, Number(form.minQty)||0), createdAt: todayISO() }
     setDb({ ...db, inventory: [it, ...db.inventory] })
-    setForm({ sku:"", name:"", qty:1, location:"", minQty:0, toReturnUSA:false })
+    setForm({ sku:"", name:"", qty:1, location:"", minQty:0 })
   }
   function removeItem(id){
     if(!confirm("Usunąć pozycję z magazynu?")) return
@@ -55,10 +55,6 @@ export default function InventoryPanel({ db, setDb, companyId }){
               <input type="number" min="0" className="input" value={form.minQty} onChange={e=>setForm({...form, minQty:Number(e.target.value)})}/>
             </div>
           </div>
-          <div style={{display:'flex', alignItems:'center', gap:8}}>
-            <input id="toReturnUSA" type="checkbox" checked={form.toReturnUSA} onChange={e=>setForm({...form, toReturnUSA:e.target.checked})} />
-            <label className="dim" htmlFor="toReturnUSA">Oznacz jako „do odesłania do USA”</label>
-          </div>
           <button className="btn primary" onClick={addItem} style={{marginTop:10}}>Dodaj do magazynu</button>
         </div>
       </div>
@@ -74,7 +70,7 @@ export default function InventoryPanel({ db, setDb, companyId }){
           <div className="header">Stan magazynu</div>
           <div className="body" style={{overflowX:'auto'}}>
             <table>
-              <thead><tr><th>Nazwa</th><th>SKU</th><th>Lokalizacja</th><th>Stan</th><th>Min</th><th>Do USA</th><th>Akcje</th></tr></thead>
+              <thead><tr><th>Nazwa</th><th>SKU</th><th>Lokalizacja</th><th>Stan</th><th>Min</th><th>Akcje</th></tr></thead>
               <tbody>
                 {shown.map(i => (
                   <tr key={i.id} className={i.qty <= i.minQty ? "low" : ""}>
@@ -88,7 +84,6 @@ export default function InventoryPanel({ db, setDb, companyId }){
                       </span>
                     </td>
                     <td>{i.minQty}</td>
-                    <td>{i.toReturnUSA ? "tak" : "nie"}</td>
                     <td>
                       <div className="row-actions">
                         <button className="btn" onClick={()=>adjustQty(i.id, +1)}>+1</button>
@@ -98,7 +93,7 @@ export default function InventoryPanel({ db, setDb, companyId }){
                     </td>
                   </tr>
                 ))}
-                {shown.length===0 && <tr><td colSpan="7" style={{textAlign:'center', padding:'16px'}} className="dim">Magazyn pusty</td></tr>}
+                {shown.length===0 && <tr><td colSpan="6" style={{textAlign:'center', padding:'16px'}} className="dim">Magazyn pusty</td></tr>}
               </tbody>
             </table>
           </div>

--- a/src/components/JobsPanel.jsx
+++ b/src/components/JobsPanel.jsx
@@ -280,7 +280,7 @@ function JobDetails({ job, total }){
       ) : (
         <ul style={{paddingLeft:18, margin:0}}>
           {job.inventoryUsed.map((u, idx) => (
-            <li key={idx}>{u.name} (SKU: {u.sku}) — {u.qty} szt. — los: {u.disposition==="return"?"zwrócone do USA": u.disposition==="dispose"?"utylizacja":"pozostaje u mnie"}</li>
+            <li key={idx}>{u.name} (SKU: {u.sku}) — {u.qty} szt. — los: {u.disposition==="dispose"?"utylizacja":"pozostaje u mnie"}</li>
           ))}
         </ul>
       )}
@@ -322,7 +322,6 @@ function InventoryUsageEditor({ usage, setUsage, inventory }){
           <div className="label">Los części</div>
           <select className="input" value={disp} onChange={e=>setDisp(e.target.value)}>
             <option value="keep">Pozostaje u mnie</option>
-            <option value="return">Zwrócić do USA</option>
             <option value="dispose">Utylizacja</option>
           </select>
         </div>
@@ -338,7 +337,7 @@ function InventoryUsageEditor({ usage, setUsage, inventory }){
                 <tr><td colSpan="5" style={{textAlign:'center', padding:'12px'}} className="dim">Nic nie dodano</td></tr>
               ) : usage.map((u, idx) => (
                 <tr key={idx}>
-                  <td>{u.name}</td><td>{u.sku}</td><td>{u.qty}</td><td>{u.disposition==="return"?"zwrócić do USA":u.disposition==="dispose"?"utylizacja":"pozostaje u mnie"}</td>
+                  <td>{u.name}</td><td>{u.sku}</td><td>{u.qty}</td><td>{u.disposition==="dispose"?"utylizacja":"pozostaje u mnie"}</td>
                   <td style={{textAlign:'right'}}><button className="btn ghost" onClick={()=>removeLine(u.itemId, u.disposition)}>Usuń</button></td>
                 </tr>
               ))}

--- a/src/components/ReportsPanel.jsx
+++ b/src/components/ReportsPanel.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react'
 import { DEFAULT_STATUSES, JOB_TYPES, fmtPLN } from '../utils'
 
-export default function ReportsPanel({ jobs, inventory }){
+export default function ReportsPanel({ jobs }){
   const [from, setFrom] = useState("")
   const [to, setTo] = useState("")
 
@@ -20,22 +20,14 @@ export default function ReportsPanel({ jobs, inventory }){
 
   const allUsages = inRange.flatMap(j=>j.inventoryUsed||[])
   const totalParts = allUsages.reduce((a,u)=>a+Number(u.qty||0),0)
-  const partsByDisp = [
-    { key:"return", label:"Zwrócone do USA", count: allUsages.filter(u=>u.disposition==="return").reduce((a,u)=>a+Number(u.qty||0),0) },
-    { key:"keep", label:"Pozostały u mnie", count: allUsages.filter(u=>u.disposition==="keep").reduce((a,u)=>a+Number(u.qty||0),0) },
-    { key:"dispose", label:"Utylizacja", count: allUsages.filter(u=>u.disposition==="dispose").reduce((a,u)=>a+Number(u.qty||0),0) },
-  ]
+  const keptParts = allUsages.filter(u=>u.disposition==="keep").reduce((a,u)=>a+Number(u.qty||0),0)
+  const disposedParts = allUsages.filter(u=>u.disposition==="dispose").reduce((a,u)=>a+Number(u.qty||0),0)
 
   const shipInSum = inRange.reduce((s,j)=> s + Number(j.shipIn||0), 0)
   const shipOutSum = inRange.reduce((s,j)=> s + Number(j.shipOut||0), 0)
   const insInSum = inRange.reduce((s,j)=> s + Number(j.insIn||0), 0)
   const insOutSum = inRange.reduce((s,j)=> s + Number(j.insOut||0), 0)
   const shipTotal = shipInSum + shipOutSum + insInSum + insOutSum
-
-  const inventoryMap = new Map(inventory.map(i=>[i.id,i]))
-  const mustReturnUsed = allUsages.filter(u => inventoryMap.get(u.itemId)?.toReturnUSA)
-  const mustReturnQty = mustReturnUsed.reduce((a,u)=>a+Number(u.qty||0),0)
-  const mustReturnActuallyReturned = mustReturnUsed.filter(u=>u.disposition==="return").reduce((a,u)=>a+Number(u.qty||0),0)
 
   return (
     <div className="grid" style={{gap:16, gridTemplateColumns:'1fr 1fr'}}>
@@ -85,21 +77,18 @@ export default function ReportsPanel({ jobs, inventory }){
         <div className="header">Podsumowanie części</div>
         <div className="body">
           <div>Łącznie użytych (szt.): <strong>{totalParts}</strong></div>
-          <div className="grid" style={{gridTemplateColumns:'1fr 1fr 1fr', gap:12, marginTop:8}}>
-            {partsByDisp.map(p => (
-              <div key={p.key} className="card">
-                <div className="body">
-                  <div className="dim" style={{fontSize:12}}>{p.label}</div>
-                  <div style={{fontSize:24, fontWeight:700}}>{p.count}</div>
-                </div>
+          <div className="grid" style={{gridTemplateColumns:'1fr 1fr', gap:12, marginTop:8}}>
+            <div className="card">
+              <div className="body">
+                <div className="dim" style={{fontSize:12}}>Pozostały u mnie</div>
+                <div style={{fontSize:24, fontWeight:700}}>{keptParts}</div>
               </div>
-            ))}
-          </div>
-          <div className="card" style={{marginTop:12}}>
-            <div className="body" style={{fontSize:14}}>
-              <div style={{fontWeight:600, marginBottom:4}}>Kontrola zwrotów do USA</div>
-              <div>Oznaczone w magazynie jako „do USA”: <strong>{mustReturnQty}</strong> szt.</div>
-              <div>Rzeczywiście odesłane: <strong>{mustReturnActuallyReturned}</strong> szt.</div>
+            </div>
+            <div className="card">
+              <div className="body">
+                <div className="dim" style={{fontSize:12}}>Utylizacja</div>
+                <div style={{fontSize:24, fontWeight:700}}>{disposedParts}</div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,8 +38,8 @@ export function loadDb(withDemo=false){
       { id: uid(), companyId: c1.id, orderNumber: "ZL-2025-002", serialNumber:"SN55555", issueDesc:"Brak obrazu", incomingTracking:"INPOST-XYZ", outgoingTracking:"", actionsDesc:"Wymiana kondensatora", status:"czeka", jobType:"onsite", dueDate:"", shipIn:0, shipOut:0, insIn:0, insOut:0, createdAt: todayISO(), updatedAt: todayISO(), inventoryUsed: []},
     ],
     inventory: [
-      { id: uid(), companyId: c1.id, sku:"KND-100", name:"Kondensator 100uF", qty:12, location:"A1", minQty:5, toReturnUSA:false, createdAt: todayISO()},
-      { id: uid(), companyId: c1.id, sku:"PSU-12V", name:"Zasilacz 12V", qty:3, location:"B2", minQty:2, toReturnUSA:true, createdAt: todayISO()},
+      { id: uid(), companyId: c1.id, sku:"KND-100", name:"Kondensator 100uF", qty:12, location:"A1", minQty:5, createdAt: todayISO()},
+      { id: uid(), companyId: c1.id, sku:"PSU-12V", name:"Zasilacz 12V", qty:3, location:"B2", minQty:2, createdAt: todayISO()},
     ],
   }
   return withDemo ? demo : { companies: [], jobs: [], inventory: [] }
@@ -53,8 +53,12 @@ export function migrate(data){
     jobType: j.jobType || "hub",
     shipIn: Number(j.shipIn||0), shipOut: Number(j.shipOut||0),
     insIn: Number(j.insIn||0), insOut: Number(j.insOut||0),
-    inventoryUsed: (j.inventoryUsed||[]).map(u => ({...u, qty: Number(u.qty||0), disposition: u.disposition || "keep"})),
+    inventoryUsed: (j.inventoryUsed||[]).map(u => ({
+      ...u,
+      qty: Number(u.qty||0),
+      disposition: u.disposition === "dispose" ? "dispose" : "keep"
+    })),
   }))
-  const inventory = (data.inventory||[]).map(i => ({...i, toReturnUSA: !!i.toReturnUSA}))
+  const inventory = (data.inventory||[]).map(({ toReturnUSA, ...i }) => ({ ...i }))
   return { companies: data.companies||[], jobs, inventory }
 }


### PR DESCRIPTION
## Summary
- drop `toReturnUSA` flag from inventory and UI
- remove "Zwrócić do USA" disposition option from jobs
- simplify reports by eliminating USA return sections and data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7c7082dec832fb8bcfe68b0e3f859