### PR TITLE
Add repairQueue and partEvents arrays

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -42,8 +42,10 @@ export function loadDb(withDemo=false){
       { id: uid(), companyId: c1.id, sku:"KND-100", name:"Kondensator 100uF", qty:12, location:"A1", minQty:5, createdAt: todayISO()},
       { id: uid(), companyId: c1.id, sku:"PSU-12V", name:"Zasilacz 12V", qty:3, location:"B2", minQty:2, createdAt: todayISO()},
     ],
+    repairQueue: [],
+    partEvents: [],
   }
-  return withDemo ? demo : { companies: [], jobs: [], inventory: [] }
+  return withDemo ? demo : { companies: [], jobs: [], inventory: [], repairQueue: [], partEvents: [] }
 }
 
 export function saveDb(db){ try { localStorage.setItem(STORAGE_KEY, JSON.stringify(db)) } catch {} }
@@ -57,9 +59,15 @@ export function migrate(data){
     inventoryUsed: (j.inventoryUsed||[]).map(u => ({
       ...u,
       qty: Number(u.qty||0),
-      disposition: u.disposition === "dispose" ? "dispose" : "keep"
+      disposition: u.disposition
     })),
   }))
   const inventory = (data.inventory||[]).map(({ toReturnUSA, ...i }) => ({ ...i }))
-  return { companies: data.companies||[], jobs, inventory }
+  return {
+    companies: data.companies||[],
+    jobs,
+    inventory,
+    repairQueue: data.repairQueue||[],
+    partEvents: data.partEvents||[]
+  }
 }


### PR DESCRIPTION
## Summary
- add `repairQueue` and `partEvents` to the default database structure and demo data
- extend migration to keep `disposition` values and expose `repairQueue` and `partEvents`

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d52a7248832fb8165f40dda36db1