### PR TITLE
Log repair queue outcomes in part events

### DIFF
--- a/src/components/JobsPanel.jsx
+++ b/src/components/JobsPanel.jsx
@@ -29,6 +29,12 @@ export default function JobsPanel({ db, setDb, companyId }){
 
   const jobs = useMemo(()=> db.jobs.filter(j=>j.companyId===companyId), [db, companyId])
   const inventory = useMemo(()=> db.inventory.filter(i=>i.companyId===companyId), [db, companyId])
+  const jobMap = useMemo(()=>{
+    const map = new Map()
+    for(const job of jobs) map.set(job.id, job)
+    return map
+  }, [jobs])
+  const repairQueue = useMemo(()=> db.repairQueue.filter(r=>r.companyId===companyId), [db, companyId])
 
   const shown = useMemo(()=>{
     let arr=[...jobs]
@@ -102,9 +108,9 @@ export default function JobsPanel({ db, setDb, companyId }){
     for(const u of after){
       const qty = Number(u.qty||0)
       if(u.disposition === 'renew' || u.disposition === 'return'){
-        repairAdds.push({ id: uid(), jobId: editId, name: u.name, sku: u.sku, qty, disposition: u.disposition, companyId, createdAt: todayISO() })
+        repairAdds.push({ id: uid(), jobId: editId, itemId: u.itemId, name: u.name, sku: u.sku, qty, disposition: u.disposition, companyId, createdAt: todayISO() })
       } else if(u.disposition === 'dispose'){
-        partAdds.push({ id: uid(), companyId, jobId: editId, itemId: u.itemId, qty, date: todayISO() })
+        partAdds.push({ id: uid(), companyId, jobId: editId, itemId: u.itemId, sku: u.sku, name: u.name, qty, type: 'dispose', eventDate: todayISO() })
       }
     }
     const newRepairQueue = [...baseRepairQueue, ...repairAdds]
@@ -113,6 +119,53 @@ export default function JobsPanel({ db, setDb, companyId }){
     setUsageOpen(false)
     setEditId(null)
   }
+
+  function resolveQueueItem(id, action){
+    const entry = db.repairQueue.find(r=>r.id===id && r.companyId===companyId)
+    if(!entry) return
+    const qty = Number(entry.qty||0)
+    const remainingQueue = db.repairQueue.filter(r=>r.id!==id)
+
+    let inventoryUpdate = db.inventory
+    if(action==='ok' && entry.itemId){
+      inventoryUpdate = db.inventory.map(it => {
+        if(it.id===entry.itemId && it.companyId===companyId){
+          return { ...it, qty: it.qty + qty }
+        }
+        return it
+      })
+    }
+
+    let partEventsUpdate = db.partEvents
+    if(action==='bad' || action==='return'){
+      const type = action==='bad' ? 'dispose' : 'return'
+      partEventsUpdate = [
+        ...db.partEvents,
+        {
+          id: uid(),
+          companyId,
+          jobId: entry.jobId,
+          itemId: entry.itemId,
+          sku: entry.sku,
+          name: entry.name,
+          qty,
+          type,
+          eventDate: todayISO(),
+        }
+      ]
+    }
+
+    setDb({
+      ...db,
+      inventory: inventoryUpdate,
+      repairQueue: remainingQueue,
+      partEvents: partEventsUpdate,
+    })
+  }
+
+  const queueOk = (id) => resolveQueueItem(id, 'ok')
+  const queueBad = (id) => resolveQueueItem(id, 'bad')
+  const queueReturn = (id) => resolveQueueItem(id, 'return')
 
   const totalShip = (j)=> Number(j.shipIn||0)+Number(j.shipOut||0)+Number(j.insIn||0)+Number(j.insOut||0)
 
@@ -243,6 +296,52 @@ export default function JobsPanel({ db, setDb, companyId }){
                   </React.Fragment>
                 ))}
                 {shown.length===0 && <tr><td colSpan="7" style={{textAlign:'center', padding:'16px', color:'#64748b'}}>Brak zleceń spełniających kryteria</td></tr>}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="card" style={{marginTop:16}}>
+          <div className="header">Kolejka części</div>
+          <div className="body" style={{overflowX:'auto'}}>
+            <table>
+              <thead>
+                <tr>
+                  <th>Data</th>
+                  <th>Zlecenie</th>
+                  <th>Część</th>
+                  <th>SKU</th>
+                  <th>Ilość</th>
+                  <th>Los</th>
+                  <th>Akcje</th>
+                </tr>
+              </thead>
+              <tbody>
+                {repairQueue.length===0 ? (
+                  <tr><td colSpan={7} style={{textAlign:'center', padding:'16px'}} className="dim">Kolejka pusta</td></tr>
+                ) : repairQueue
+                  .slice()
+                  .sort((a,b)=> new Date(b.createdAt||0) - new Date(a.createdAt||0))
+                  .map(item => {
+                    const job = jobMap.get(item.jobId)
+                    return (
+                      <tr key={item.id}>
+                        <td>{item.createdAt ? new Date(item.createdAt).toLocaleString() : '—'}</td>
+                        <td>{job ? job.orderNumber : '—'}</td>
+                        <td>{item.name}</td>
+                        <td>{item.sku}</td>
+                        <td>{item.qty}</td>
+                        <td>{DISPOSITION_LABELS[item.disposition] || item.disposition}</td>
+                        <td>
+                          <div className="row-actions">
+                            <button className="btn" onClick={()=>queueOk(item.id)} disabled={!item.itemId}>OK</button>
+                            <button className="btn danger" onClick={()=>queueBad(item.id)}>BAD</button>
+                            <button className="btn" onClick={()=>queueReturn(item.id)}>Odesłano</button>
+                          </div>
+                        </td>
+                      </tr>
+                    )
+                  })}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## Summary
- add a repair queue section that lets users resolve parts with OK, BAD or Odesłano actions and records the outcomes
- ensure immediate dispose events capture part metadata when saving job usage
- normalize migrated repair queue and part event records so every entry carries the required fields

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9028eb384832f847067271f3d8713