### PR TITLE
Ensure repair queue defaults and validation in migrate

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -79,7 +79,9 @@ export function migrate(data){
       name: r.name || "",
       sku: r.sku || "",
       qty: Number(r.qty||0),
-      disposition: r.disposition || 'renew',
+      disposition: ["dispose", "renew", "return"].includes(r.disposition)
+        ? r.disposition
+        : "renew",
       createdAt: r.createdAt || r.addedAt || todayISO(),
     }
   }).filter(Boolean)
@@ -105,7 +107,7 @@ export function migrate(data){
     companies: data.companies||[],
     jobs,
     inventory,
-    repairQueue,
-    partEvents
+    repairQueue: repairQueue.length ? repairQueue : (data.repairQueue || []),
+    partEvents: partEvents.length ? partEvents : (data.partEvents || []),
   }
 }


### PR DESCRIPTION
## Summary
- Default `repairQueue` and `partEvents` to incoming data or empty arrays when migrating
- Validate repair queue item fields, enforcing numeric `qty` and allowed `disposition`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c91e7b07c8832facb9ad0ec0f8a077