### PR TITLE
Add renew part event tracking and report tile

### DIFF
--- a/src/components/JobsPanel.jsx
+++ b/src/components/JobsPanel.jsx
@@ -137,8 +137,8 @@ export default function JobsPanel({ db, setDb, companyId }){
     }
 
     let partEventsUpdate = db.partEvents
-    if(action==='bad' || action==='return'){
-      const type = action==='bad' ? 'dispose' : 'return'
+    if((action==='bad' || action==='return' || action==='ok') && entry.itemId){
+      const type = action==='bad' ? 'dispose' : action==='return' ? 'return' : 'renew'
       partEventsUpdate = [
         ...db.partEvents,
         {

--- a/src/components/RepairQueuePanel.jsx
+++ b/src/components/RepairQueuePanel.jsx
@@ -35,8 +35,8 @@ export default function RepairQueuePanel({ db, setDb, companyId }){
     }
 
     let partEventsUpdate = db.partEvents
-    if(action==='bad' || action==='return'){
-      const type = action==='bad' ? 'dispose' : 'return'
+    if((action==='bad' || action==='return' || action==='ok') && entry.itemId){
+      const type = action==='bad' ? 'dispose' : action==='return' ? 'return' : 'renew'
       partEventsUpdate = [
         ...db.partEvents,
         {

--- a/src/components/ReportsPanel.jsx
+++ b/src/components/ReportsPanel.jsx
@@ -39,6 +39,7 @@ export default function ReportsPanel({ jobs, partEvents }){
 
   const disposedEvents = eventsInRange.filter(e=>e.type==="dispose").reduce((a,e)=>a+Number(e.qty||0),0)
   const returnedEvents = eventsInRange.filter(e=>e.type==="return").reduce((a,e)=>a+Number(e.qty||0),0)
+  const renewEventsCount = eventsInRange.filter(e=>e.type==="renew").length
 
   const shipInSum = jobsInRange.reduce((s,j)=> s + Number(j.shipIn||0), 0)
   const shipOutSum = jobsInRange.reduce((s,j)=> s + Number(j.shipOut||0), 0)
@@ -94,7 +95,7 @@ export default function ReportsPanel({ jobs, partEvents }){
         <div className="header">Podsumowanie części</div>
         <div className="body">
           <div>Łącznie użytych (szt.): <strong>{totalParts}</strong></div>
-          <div className="grid" style={{gridTemplateColumns:'1fr 1fr', gap:12, marginTop:8}}>
+          <div className="grid" style={{gridTemplateColumns:'repeat(auto-fit, minmax(140px, 1fr))', gap:12, marginTop:8}}>
             <div className="card">
               <div className="body">
                 <div className="dim" style={{fontSize:12}}>Pozostały u mnie</div>
@@ -108,7 +109,7 @@ export default function ReportsPanel({ jobs, partEvents }){
               </div>
             </div>
           </div>
-          <div className="grid" style={{gridTemplateColumns:'1fr 1fr', gap:12, marginTop:8}}>
+          <div className="grid" style={{gridTemplateColumns:'repeat(auto-fit, minmax(140px, 1fr))', gap:12, marginTop:8}}>
             <div className="card">
               <div className="body">
                 <div className="dim" style={{fontSize:12}}>Utylizacje</div>
@@ -119,6 +120,12 @@ export default function ReportsPanel({ jobs, partEvents }){
               <div className="body">
                 <div className="dim" style={{fontSize:12}}>Odesłania</div>
                 <div style={{fontSize:24, fontWeight:700}}>{returnedEvents}</div>
+              </div>
+            </div>
+            <div className="card">
+              <div className="body">
+                <div className="dim" style={{fontSize:12}}>Odnowienia (liczba pozycji)</div>
+                <div style={{fontSize:24, fontWeight:700}}>{renewEventsCount}</div>
               </div>
             </div>
           </div>

--- a/src/utils.js
+++ b/src/utils.js
@@ -96,7 +96,7 @@ export function migrate(data){
     const companyId = ev.companyId || job?.companyId || null
     if(!companyId) return null
     const rawType = ev.type || ev.eventType || ev.disposition
-    const type = rawType === 'return' ? 'return' : 'dispose'
+    const type = rawType === 'return' ? 'return' : rawType === 'renew' ? 'renew' : 'dispose'
     return {
       id: ev.id || uid(),
       companyId,


### PR DESCRIPTION
## Summary
- add renew part event logging when queue items are confirmed with OK
- surface renew part events in reports with a new tile and responsive layout
- keep renew event data during migrations

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c9273faabc832f90d524b55152468f