### PR TITLE
Highlight low inventory rows

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -31,3 +31,4 @@ th { font-weight: 500; color:#64748b; }
 .row-actions { display:flex; flex-wrap:wrap; gap:6px; }
 .danger-text { color:#b91c1c; }
 .dim { color:#64748b; }
+.low { background:#fef2f2; color:#991b1b; }


### PR DESCRIPTION
## Summary
- add a low inventory style to emphasize rows flagged as `qty <= minQty`

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68c9b32a4a20832faa7fafe2bfde65cc