### PR TITLE
Remove queue tab and embed repair queue in inventory

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,6 @@ import ImportExport from './components/ImportExport.jsx'
 import JobsPanel from './components/JobsPanel.jsx'
 import InventoryPanel from './components/InventoryPanel.jsx'
 import ReportsPanel from './components/ReportsPanel.jsx'
-import RepairQueuePanel from './components/RepairQueuePanel.jsx'
 
 export default function App(){
   const [db, setDb] = useState(()=> migrate(loadDb()))
@@ -30,7 +29,7 @@ export default function App(){
             <div className="logo"></div>
             <div>
               <div style={{fontWeight:700}}>Serwis Manager</div>
-              <div className="muted" style={{fontSize:12}}>Zlecenia • Kolejka • Magazyn • Raporty</div>
+              <div className="muted" style={{fontSize:12}}>Zlecenia • Magazyn • Raporty</div>
             </div>
           </div>
           <div style={{display:'flex', gap:8}}>
@@ -47,13 +46,11 @@ export default function App(){
           <>
             <div className="tabs">
               <button className={"btn " + (tab==="jobs"?"primary":"")} onClick={()=>setTab("jobs")}>Zlecenia</button>
-              <button className={"btn " + (tab==="queue"?"primary":"")} onClick={()=>setTab("queue")}>Kolejka</button>
               <button className={"btn " + (tab==="inv"?"primary":"")} onClick={()=>setTab("inv")}>Magazyn</button>
               <button className={"btn " + (tab==="rep"?"primary":"")} onClick={()=>setTab("rep")}>Raport</button>
             </div>
 
             {tab==="jobs" && <JobsPanel db={db} setDb={setDb} companyId={companyId} />}
-            {tab==="queue" && <RepairQueuePanel db={db} setDb={setDb} companyId={companyId} />}
             {tab==="inv" && <InventoryPanel db={db} setDb={setDb} companyId={companyId} />}
             {tab==="rep" && <ReportsPanel jobs={jobs} partEvents={partEvents} />}
           </>

--- a/src/components/InventoryPanel.jsx
+++ b/src/components/InventoryPanel.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react'
+import RepairQueuePanel from './RepairQueuePanel.jsx'
 import { todayISO, uid } from '../utils'
 
 export default function InventoryPanel({ db, setDb, companyId }){
@@ -97,6 +98,10 @@ export default function InventoryPanel({ db, setDb, companyId }){
               </tbody>
             </table>
           </div>
+        </div>
+
+        <div style={{marginTop:16}}>
+          <RepairQueuePanel db={db} setDb={setDb} companyId={companyId} />
         </div>
       </div>
     </div>

--- a/src/components/JobsPanel.jsx
+++ b/src/components/JobsPanel.jsx
@@ -29,13 +29,6 @@ export default function JobsPanel({ db, setDb, companyId }){
 
   const jobs = useMemo(()=> db.jobs.filter(j=>j.companyId===companyId), [db, companyId])
   const inventory = useMemo(()=> db.inventory.filter(i=>i.companyId===companyId), [db, companyId])
-  const jobMap = useMemo(()=>{
-    const map = new Map()
-    for(const job of jobs) map.set(job.id, job)
-    return map
-  }, [jobs])
-  const repairQueue = useMemo(()=> db.repairQueue.filter(r=>r.companyId===companyId), [db, companyId])
-
   const shown = useMemo(()=>{
     let arr=[...jobs]
     if(statusFilter!=="all") arr=arr.filter(j=>j.status===statusFilter)
@@ -119,53 +112,6 @@ export default function JobsPanel({ db, setDb, companyId }){
     setUsageOpen(false)
     setEditId(null)
   }
-
-  function resolveQueueItem(id, action){
-    const entry = db.repairQueue.find(r=>r.id===id && r.companyId===companyId)
-    if(!entry) return
-    const qty = Number(entry.qty||0)
-    const remainingQueue = db.repairQueue.filter(r=>r.id!==id)
-
-    let inventoryUpdate = db.inventory
-    if(action==='ok' && entry.itemId){
-      inventoryUpdate = db.inventory.map(it => {
-        if(it.id===entry.itemId && it.companyId===companyId){
-          return { ...it, qty: it.qty + qty }
-        }
-        return it
-      })
-    }
-
-    let partEventsUpdate = db.partEvents
-    if((action==='bad' || action==='return' || action==='ok') && entry.itemId){
-      const type = action==='bad' ? 'dispose' : action==='return' ? 'return' : 'renew'
-      partEventsUpdate = [
-        ...db.partEvents,
-        {
-          id: uid(),
-          companyId,
-          jobId: entry.jobId,
-          itemId: entry.itemId,
-          sku: entry.sku,
-          name: entry.name,
-          qty,
-          type,
-          eventDate: todayISO(),
-        }
-      ]
-    }
-
-    setDb({
-      ...db,
-      inventory: inventoryUpdate,
-      repairQueue: remainingQueue,
-      partEvents: partEventsUpdate,
-    })
-  }
-
-  const queueOk = (id) => resolveQueueItem(id, 'ok')
-  const queueBad = (id) => resolveQueueItem(id, 'bad')
-  const queueReturn = (id) => resolveQueueItem(id, 'return')
 
   const totalShip = (j)=> Number(j.shipIn||0)+Number(j.shipOut||0)+Number(j.insIn||0)+Number(j.insOut||0)
 
@@ -296,52 +242,6 @@ export default function JobsPanel({ db, setDb, companyId }){
                   </React.Fragment>
                 ))}
                 {shown.length===0 && <tr><td colSpan="7" style={{textAlign:'center', padding:'16px', color:'#64748b'}}>Brak zleceń spełniających kryteria</td></tr>}
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        <div className="card" style={{marginTop:16}}>
-          <div className="header">Kolejka części</div>
-          <div className="body" style={{overflowX:'auto'}}>
-            <table>
-              <thead>
-                <tr>
-                  <th>Data</th>
-                  <th>Zlecenie</th>
-                  <th>Część</th>
-                  <th>SKU</th>
-                  <th>Ilość</th>
-                  <th>Los</th>
-                  <th>Akcje</th>
-                </tr>
-              </thead>
-              <tbody>
-                {repairQueue.length===0 ? (
-                  <tr><td colSpan={7} style={{textAlign:'center', padding:'16px'}} className="dim">Kolejka pusta</td></tr>
-                ) : repairQueue
-                  .slice()
-                  .sort((a,b)=> new Date(b.createdAt||0) - new Date(a.createdAt||0))
-                  .map(item => {
-                    const job = jobMap.get(item.jobId)
-                    return (
-                      <tr key={item.id}>
-                        <td>{item.createdAt ? new Date(item.createdAt).toLocaleString() : '—'}</td>
-                        <td>{job ? job.orderNumber : '—'}</td>
-                        <td>{item.name}</td>
-                        <td>{item.sku}</td>
-                        <td>{item.qty}</td>
-                        <td>{DISPOSITION_LABELS[item.disposition] || item.disposition}</td>
-                        <td>
-                          <div className="row-actions">
-                            <button className="btn" onClick={()=>queueOk(item.id)} disabled={!item.itemId}>OK</button>
-                            <button className="btn danger" onClick={()=>queueBad(item.id)}>BAD</button>
-                            <button className="btn" onClick={()=>queueReturn(item.id)}>Odesłano</button>
-                          </div>
-                        </td>
-                      </tr>
-                    )
-                  })}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## Summary
- remove the queue-specific state and UI from the jobs panel
- render the repair queue inside the inventory section and drop the standalone tab

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9b80570e4832fa7b3e12df886a920