### PR TITLE
Limit inventory table height with vertical scrolling

### DIFF
--- a/src/components/InventoryPanel.jsx
+++ b/src/components/InventoryPanel.jsx
@@ -69,7 +69,7 @@ export default function InventoryPanel({ db, setDb, companyId }){
 
         <div className="card" style={{marginTop:16}}>
           <div className="header">Stan magazynu</div>
-          <div className="body" style={{overflowX:'auto'}}>
+          <div className="body inventory-table">
             <table>
               <thead><tr><th>Nazwa</th><th>SKU</th><th>Lokalizacja</th><th>Stan</th><th>Min</th><th>Akcje</th></tr></thead>
               <tbody>

--- a/src/styles.css
+++ b/src/styles.css
@@ -21,6 +21,7 @@ textarea { min-height: 80px; }
 .card { border:1px solid #e2e8f0; background:#fff; border-radius: var(--radius); box-shadow: 0 2px 0 rgba(0,0,0,0.03); }
 .card .header { border-bottom:1px solid #e2e8f0; padding:12px 16px; font-weight:700; }
 .card .body { padding:16px; }
+.inventory-table { overflow-x: auto; overflow-y: auto; max-height: 280px; }
 .tabs { display:flex; gap:8px; margin: 12px 0 16px; flex-wrap: wrap; }
 .tab { composes: btn; }
 .tab.active { background:#0f172a; color:#fff; border-color:#0f172a; }


### PR DESCRIPTION
## Summary
- add a reusable inventory-table class with horizontal and vertical scrolling and capped height
- apply the new class to the inventory table container to show a scrollbar after five rows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bd44271c832fa31f64ef5065738d