### PR TITLE
Increase inventory table max height

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -21,7 +21,7 @@ textarea { min-height: 80px; }
 .card { border:1px solid #e2e8f0; background:#fff; border-radius: var(--radius); box-shadow: 0 2px 0 rgba(0,0,0,0.03); }
 .card .header { border-bottom:1px solid #e2e8f0; padding:12px 16px; font-weight:700; }
 .card .body { padding:16px; }
-.inventory-table { overflow-x: auto; overflow-y: auto; max-height: 280px; }
+.inventory-table { overflow-x: auto; overflow-y: auto; max-height: 560px; }
 .tabs { display:flex; gap:8px; margin: 12px 0 16px; flex-wrap: wrap; }
 .tab { composes: btn; }
 .tab.active { background:#0f172a; color:#fff; border-color:#0f172a; }


### PR DESCRIPTION
## Summary
- double the inventory table's max-height to allow more rows before scrolling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9c194f9b4832faf3aae18177f719b