### PR TITLE
Align repair queue table scrolling

### DIFF
--- a/src/components/RepairQueuePanel.jsx
+++ b/src/components/RepairQueuePanel.jsx
@@ -68,7 +68,7 @@ export default function RepairQueuePanel({ db, setDb, companyId }){
   return (
     <div className="card">
       <div className="header">Kolejka części</div>
-      <div className="body" style={{overflowX:'auto'}}>
+      <div className="body inventory-table">
         <table>
           <thead>
             <tr>


### PR DESCRIPTION
## Summary
- apply the shared inventory-table styling to the repair queue table container to match scroll behavior with the inventory panel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9ca1a7634832faf195f6c1c1fb90a