### PR TITLE
Refine jobs filters layout

### DIFF
--- a/src/components/JobsPanel.jsx
+++ b/src/components/JobsPanel.jsx
@@ -206,15 +206,15 @@ export default function JobsPanel({ db, setDb, companyId }){
 
       <div>
         <div className="card">
-          <div className="body" style={{display:'flex', gap:8, flexWrap:'wrap'}}>
-            <div style={{position:'relative', flex:1, minWidth:220}}>
+          <div className="body filter-bar">
+            <div className="filter-bar__search">
               <input className="input" placeholder="Szukaj (nr, SN, opis...)" value={search} onChange={e=>setSearch(e.target.value)} />
             </div>
-            <select className="input" value={statusFilter} onChange={e=>setStatusFilter(e.target.value)} style={{width:180}}>
+            <select className="input" value={statusFilter} onChange={e=>setStatusFilter(e.target.value)}>
               <option value="all">Wszystkie statusy</option>
               {DEFAULT_STATUSES.map(s => <option key={s.value} value={s.value}>{s.label}</option>)}
             </select>
-            <select className="input" value={typeFilter} onChange={e=>setTypeFilter(e.target.value)} style={{width:220}}>
+            <select className="input" value={typeFilter} onChange={e=>setTypeFilter(e.target.value)}>
               <option value="all">Wszystkie typy</option>
               {JOB_TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
             </select>

--- a/src/styles.css
+++ b/src/styles.css
@@ -16,6 +16,8 @@ textarea { min-height: 80px; }
 .label { display:block; font-weight:600; margin-bottom:6px; color:#334155; font-size: 13px; }
 .grid { display:grid; gap:12px; }
 .col-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.filter-bar { display:grid; gap:12px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); align-items:center; }
+.filter-bar__search { grid-column: 1 / -1; }
 .layout { display:grid; gap: 24px; grid-template-columns: 460px 1fr; align-items: start; }
 @media (max-width: 960px){ .layout{ grid-template-columns: 1fr; } }
 .card { border:1px solid #e2e8f0; background:#fff; border-radius: var(--radius); box-shadow: 0 2px 0 rgba(0,0,0,0.03); }


### PR DESCRIPTION
## Summary
- add a reusable .filter-bar grid helper for compact control layouts
- update the jobs filter row to use the helper and remove inline sizing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9d8c0491c832fbbdc2ff2f3bc03a9