### PR TITLE
Refine reports dashboard layout

### DIFF
--- a/src/components/ReportsPanel.jsx
+++ b/src/components/ReportsPanel.jsx
@@ -50,10 +50,10 @@ export default function ReportsPanel({ jobs, partEvents }){
   const shipTotal = shipmentSum + insuranceSum
 
   return (
-    <div className="grid" style={{gap:16, gridTemplateColumns:'1fr 1fr'}}>
-      <div className="card" style={{gridColumn:'1 / -1'}}>
+    <div className="dashboard-grid">
+      <div className="card dashboard-grid__full">
         <div className="header">Zakres dat</div>
-        <div className="body" style={{display:'grid', gap:12, gridTemplateColumns:'1fr 1fr'}}>
+        <div className="body grid col-2">
           <div>
             <div className="label">Od</div>
             <input type="date" className="input" value={from} onChange={e=>setFrom(e.target.value)} />
@@ -69,7 +69,7 @@ export default function ReportsPanel({ jobs, partEvents }){
         <div className="header">Podsumowanie zleceń</div>
         <div className="body">
           <div>Łącznie (w zakresie): <strong>{totalJobs}</strong></div>
-          <div className="grid" style={{gridTemplateColumns:'1fr 1fr', gap:12, marginTop:8}}>
+          <div className="summary-grid summary-grid--spaced">
             {byStatus.map(s => (
               <div key={s.status} className="card">
                 <div className="body">
@@ -80,7 +80,7 @@ export default function ReportsPanel({ jobs, partEvents }){
             ))}
           </div>
           <div style={{height:1, background:'#e2e8f0', margin:'12px 0'}}></div>
-          <div className="grid" style={{gridTemplateColumns:'1fr 1fr', gap:12}}>
+          <div className="summary-grid summary-grid--spaced">
             {byType.map(t => (
               <div key={t.type} className="card">
                 <div className="body">
@@ -97,7 +97,7 @@ export default function ReportsPanel({ jobs, partEvents }){
         <div className="header">Podsumowanie części</div>
         <div className="body">
           <div>Łącznie użytych (szt.): <strong>{totalParts}</strong></div>
-          <div className="grid" style={{gridTemplateColumns:'repeat(auto-fit, minmax(140px, 1fr))', gap:12, marginTop:8}}>
+          <div className="summary-grid summary-grid--auto summary-grid--spaced">
             <div className="card">
               <div className="body">
                 <div className="dim" style={{fontSize:12}}>Pozostały u mnie</div>
@@ -111,7 +111,7 @@ export default function ReportsPanel({ jobs, partEvents }){
               </div>
             </div>
           </div>
-          <div className="grid" style={{gridTemplateColumns:'repeat(auto-fit, minmax(140px, 1fr))', gap:12, marginTop:8}}>
+          <div className="summary-grid summary-grid--auto summary-grid--spaced">
             <div className="card">
               <div className="body">
                 <div className="dim" style={{fontSize:12}}>Utylizacje</div>
@@ -134,7 +134,7 @@ export default function ReportsPanel({ jobs, partEvents }){
         </div>
       </div>
 
-      <div className="card" style={{gridColumn:'1 / -1'}}>
+      <div className="card dashboard-grid__full">
         <div className="header">Koszty przesyłek (PLN)</div>
         <div className="body" style={{fontSize:14}}>
           <div className="grid" style={{gridTemplateColumns:'1fr 1fr', gap:12}}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -15,6 +15,11 @@ header .bar { display:flex; align-items:center; justify-content:space-between; g
 textarea { min-height: 80px; }
 .label { display:block; font-weight:600; margin-bottom:6px; color:#334155; font-size: 13px; }
 .grid { display:grid; gap:12px; }
+.dashboard-grid { display:grid; gap:16px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); align-items:start; }
+.dashboard-grid__full { grid-column: 1 / -1; }
+.summary-grid { display:grid; gap:16px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.summary-grid--spaced { margin-top:16px; }
+.summary-grid--auto { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
 .col-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 .filter-bar { display:grid; gap:12px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); align-items:center; }
 .filter-bar__search { grid-column: 1 / -1; }


### PR DESCRIPTION
## Summary
- add a reusable dashboard grid for the reports tab so cards flow with auto-fit min 320px columns
- extract shared summary grid classes for status, type, and parts cards to align nested spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9da775ce0832fa079d865eabe51ca