### PR TITLE
Add bilingual support with language switcher

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,9 +5,11 @@ import ImportExport from './components/ImportExport.jsx'
 import JobsPanel from './components/JobsPanel.jsx'
 import InventoryPanel from './components/InventoryPanel.jsx'
 import ReportsPanel from './components/ReportsPanel.jsx'
+import { useLanguage } from './i18n.jsx'
 
 export default function App(){
-  const [db, setDb] = useState(()=> migrate(loadDb()))
+  const { t, lang, toggleLanguage } = useLanguage()
+  const [db, setDb] = useState(()=> migrate(loadDb(false, lang)))
   const [tab, setTab] = useState("jobs")
   const [companyId, setCompanyId] = useState(db.companies[0]?.id || "")
 
@@ -21,6 +23,9 @@ export default function App(){
     [db, companyId]
   )
 
+  const nextLanguage = lang === 'pl' ? 'en' : 'pl'
+  const toggleLabel = t('app.languageToggle.aria', { language: t(`common.languageNames.${nextLanguage}`) })
+
   return (
     <div>
       <header>
@@ -28,11 +33,22 @@ export default function App(){
           <div className="brand">
             <div className="logo"></div>
             <div>
-              <div style={{fontWeight:700}}>Serwis Manager</div>
-              <div className="muted" style={{fontSize:12}}>Zlecenia • Magazyn • Raporty</div>
+              <div style={{fontWeight:700}}>{t('app.title')}</div>
+              <div className="muted" style={{fontSize:12}}>{t('app.subtitle')}</div>
             </div>
           </div>
-          <div style={{display:'flex', gap:8}}>
+          <div style={{display:'flex', gap:8, alignItems:'center'}}>
+            <button
+              type="button"
+              className="btn"
+              onClick={toggleLanguage}
+              title={toggleLabel}
+              aria-label={toggleLabel}
+            >
+              <span style={{fontWeight: lang === 'pl' ? 700 : 400}}>{t('common.languageShort.pl')}</span>
+              <span style={{opacity:0.6}}> / </span>
+              <span style={{fontWeight: lang === 'en' ? 700 : 400}}>{t('common.languageShort.en')}</span>
+            </button>
             <CompanySwitcher db={db} setDb={setDb} companyId={companyId} setCompanyId={setCompanyId} />
             <ImportExport db={db} setDb={setDb} />
           </div>
@@ -45,9 +61,15 @@ export default function App(){
         ) : (
           <>
             <div className="tabs">
-              <button className={"btn " + (tab==="jobs"?"primary":"")} onClick={()=>setTab("jobs")}>Zlecenia</button>
-              <button className={"btn " + (tab==="inv"?"primary":"")} onClick={()=>setTab("inv")}>Magazyn</button>
-              <button className={"btn " + (tab==="rep"?"primary":"")} onClick={()=>setTab("rep")}>Raport</button>
+              <button className={"btn " + (tab==="jobs"?"primary":"")} onClick={()=>setTab("jobs")}>
+                {t('app.tabs.jobs')}
+              </button>
+              <button className={"btn " + (tab==="inv"?"primary":"")} onClick={()=>setTab("inv")}>
+                {t('app.tabs.inventory')}
+              </button>
+              <button className={"btn " + (tab==="rep"?"primary":"")} onClick={()=>setTab("rep")}>
+                {t('app.tabs.reports')}
+              </button>
             </div>
 
             {tab==="jobs" && <JobsPanel db={db} setDb={setDb} companyId={companyId} />}
@@ -55,24 +77,25 @@ export default function App(){
             {tab==="rep" && <ReportsPanel jobs={jobs} partEvents={partEvents} />}
           </>
         )}
-        <div className="muted" style={{fontSize:12, padding:'12px 0 36px'}}>Dane lokalnie w przeglądarce. Import/Export = kopia/przenoszenie.</div>
+        <div className="muted" style={{fontSize:12, padding:'12px 0 36px'}}>{t('app.footerNotice')}</div>
       </main>
     </div>
   )
 }
 
 function EmptyState({ setDb }){
+  const { t, lang } = useLanguage()
   function loadDemo(){
-    const demo = loadDb(true)
+    const demo = loadDb(true, lang)
     saveDb(demo)
     setDb(migrate(demo))
   }
   return (
     <div className="card" style={{maxWidth:560, margin:'24px auto', textAlign:'center'}}>
       <div className="body">
-        <h2>Zacznij od dodania firmy</h2>
-        <p className="muted">Aplikacja gotowa do pracy. Dodaj firmę, a potem twórz zlecenia i zarządzaj magazynem.</p>
-        <button className="btn" onClick={loadDemo}>Wczytaj dane przykładowe</button>
+        <h2>{t('emptyState.title')}</h2>
+        <p className="muted">{t('emptyState.description')}</p>
+        <button className="btn" onClick={loadDemo}>{t('emptyState.loadDemo')}</button>
       </div>
     </div>
   )

--- a/src/components/CompanySwitcher.jsx
+++ b/src/components/CompanySwitcher.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react'
 import { todayISO, uid } from '../utils'
+import { useLanguage } from '../i18n.jsx'
 
 export default function CompanySwitcher({ db, setDb, companyId, setCompanyId }){
   const [open, setOpen] = useState(false)
   const [name, setName] = useState("")
+  const { t } = useLanguage()
 
   function addCompany(){
     if(!name.trim()) return
@@ -15,7 +17,7 @@ export default function CompanySwitcher({ db, setDb, companyId, setCompanyId }){
   }
   function removeCurrent(){
     if(db.companies.length<=1) return
-    if(!confirm("Usunąć bieżącą firmę? Z danymi!")) return
+    if(!confirm(t('companySwitcher.confirmDelete'))) return
     const newCompanies = db.companies.filter(c=>c.id!==companyId)
     const newCompanyId = newCompanies[0]?.id || ""
     setCompanyId(newCompanyId)
@@ -34,16 +36,16 @@ export default function CompanySwitcher({ db, setDb, companyId, setCompanyId }){
       <select className="input" value={companyId} onChange={(e)=>setCompanyId(e.target.value)} style={{width:220}}>
         {db.companies.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
       </select>
-      <button className="btn" onClick={()=>setOpen(v=>!v)}>Firmy ▾</button>
+      <button className="btn" onClick={()=>setOpen(v=>!v)}>{t('companySwitcher.button')}</button>
       {open && (
         <div className="card" style={{position:'absolute', right:0, top:'110%', width:280}}>
           <div className="body">
-            <div className="muted" style={{fontSize:12}}>Zarządzaj</div>
-            <div className="label">Nazwa firmy</div>
-            <input className="input" value={name} onChange={e=>setName(e.target.value)} placeholder="np. ACME Sp. z o.o."/>
+            <div className="muted" style={{fontSize:12}}>{t('companySwitcher.manage')}</div>
+            <div className="label">{t('companySwitcher.nameLabel')}</div>
+            <input className="input" value={name} onChange={e=>setName(e.target.value)} placeholder={t('companySwitcher.placeholder')}/>
             <div style={{display:'flex', gap:8, marginTop:12}}>
-              <button className="btn primary" onClick={addCompany}>Dodaj</button>
-              {db.companies.length>1 && <button className="btn danger" onClick={removeCurrent}>Usuń bieżącą</button>}
+              <button className="btn primary" onClick={addCompany}>{t('companySwitcher.add')}</button>
+              {db.companies.length>1 && <button className="btn danger" onClick={removeCurrent}>{t('companySwitcher.removeCurrent')}</button>}
             </div>
           </div>
         </div>

--- a/src/components/ImportExport.jsx
+++ b/src/components/ImportExport.jsx
@@ -1,14 +1,16 @@
 import React, { useRef } from 'react'
 import { migrate } from '../utils'
+import { useLanguage } from '../i18n.jsx'
 
 export default function ImportExport({ db, setDb }){
   const fileRef = useRef(null)
+  const { t } = useLanguage()
   function onExport(){
     const blob = new Blob([JSON.stringify(db, null, 2)], { type: "application/json" })
     const url = URL.createObjectURL(blob)
     const a = document.createElement("a")
     a.href = url
-    a.download = "serwis-manager-backup-" + new Date().toISOString().slice(0,10) + ".json"
+    a.download = t('importExport.fileNamePrefix') + "-" + new Date().toISOString().slice(0,10) + ".json"
     a.click()
     URL.revokeObjectURL(url)
   }
@@ -19,10 +21,10 @@ export default function ImportExport({ db, setDb }){
     reader.onload = () => {
       try {
         const data = migrate(JSON.parse(reader.result))
-        if(!data || !data.companies) throw new Error("Nieprawidłowy plik")
+        if(!data || !data.companies) throw new Error(t('importExport.invalidFile'))
         setDb(data)
-        alert("Dane zaimportowane")
-      } catch(err){ alert("Błąd importu: " + err.message) }
+        alert(t('importExport.importSuccess'))
+      } catch(err){ alert(t('importExport.importError', { error: err.message })) }
     }
     reader.readAsText(file)
     // reset input so importing the same file again triggers change event
@@ -31,8 +33,8 @@ export default function ImportExport({ db, setDb }){
   return (
     <div style={{display:'flex', gap:8}}>
       <input ref={fileRef} type="file" accept="application/json" style={{display:'none'}} onChange={onImport} />
-      <button className="btn" onClick={()=>fileRef.current?.click()}>Import</button>
-      <button className="btn" onClick={onExport}>Eksport</button>
+      <button className="btn" onClick={()=>fileRef.current?.click()}>{t('importExport.import')}</button>
+      <button className="btn" onClick={onExport}>{t('importExport.export')}</button>
     </div>
   )
 }

--- a/src/components/InventoryPanel.jsx
+++ b/src/components/InventoryPanel.jsx
@@ -1,10 +1,12 @@
 import React, { useMemo, useState } from 'react'
 import RepairQueuePanel from './RepairQueuePanel.jsx'
 import { todayISO, uid } from '../utils'
+import { useLanguage } from '../i18n.jsx'
 
 export default function InventoryPanel({ db, setDb, companyId }){
   const [form, setForm] = useState({ sku:"", name:"", qty:1, location:"", minQty:0 })
   const [search, setSearch] = useState("")
+  const { t } = useLanguage()
   const items = useMemo(()=> db.inventory.filter(i=>i.companyId===companyId), [db, companyId])
   const shown = useMemo(()=>{
     let arr=[...items]
@@ -16,13 +18,13 @@ export default function InventoryPanel({ db, setDb, companyId }){
   }, [items, search])
 
   function addItem(){
-    if(!form.name.trim()) return alert("Podaj nazwę pozycji")
+    if(!form.name.trim()) return alert(t('inventory.alerts.nameRequired'))
     const it = { id: uid(), companyId, sku: form.sku.trim(), name: form.name.trim(), qty: Math.max(0, Number(form.qty)||0), location: form.location.trim(), minQty: Math.max(0, Number(form.minQty)||0), createdAt: todayISO() }
     setDb({ ...db, inventory: [it, ...db.inventory] })
     setForm({ sku:"", name:"", qty:1, location:"", minQty:0 })
   }
   function removeItem(id){
-    if(!confirm("Usunąć pozycję z magazynu?")) return
+    if(!confirm(t('inventory.confirm.delete'))) return
     setDb({ ...db, inventory: db.inventory.filter(i=>i.id!==id) })
   }
   function adjustQty(id, delta){
@@ -32,46 +34,46 @@ export default function InventoryPanel({ db, setDb, companyId }){
   return (
     <div className="layout">
       <div className="card">
-        <div className="header">Dodaj pozycję</div>
+        <div className="header">{t('inventory.formTitle')}</div>
         <div className="body">
-          <div className="label">Nazwa *</div>
-          <input className="input" value={form.name} onChange={e=>setForm({...form, name:e.target.value})} placeholder="np. Moduł A / Kondensator 100uF"/>
+          <div className="label">{t('inventory.nameLabel')}</div>
+          <input className="input" value={form.name} onChange={e=>setForm({...form, name:e.target.value})} placeholder={t('inventory.namePlaceholder')}/>
           <div className="grid col-2">
             <div>
-              <div className="label">SKU / indeks</div>
-              <input className="input" value={form.sku} onChange={e=>setForm({...form, sku:e.target.value})} placeholder="np. KND-100"/>
+              <div className="label">{t('inventory.skuLabel')}</div>
+              <input className="input" value={form.sku} onChange={e=>setForm({...form, sku:e.target.value})} placeholder={t('inventory.skuPlaceholder')}/>
             </div>
             <div>
-              <div className="label">Ilość początkowa</div>
+              <div className="label">{t('inventory.qtyLabel')}</div>
               <input type="number" min="0" className="input" value={form.qty} onChange={e=>setForm({...form, qty:Number(e.target.value)})}/>
             </div>
           </div>
           <div className="grid col-2" style={{alignItems:'center'}}>
             <div>
-              <div className="label">Lokalizacja</div>
-              <input className="input" value={form.location} onChange={e=>setForm({...form, location:e.target.value})} placeholder="np. Regał A3"/>
+              <div className="label">{t('inventory.locationLabel')}</div>
+              <input className="input" value={form.location} onChange={e=>setForm({...form, location:e.target.value})} placeholder={t('inventory.locationPlaceholder')}/>
             </div>
             <div>
-              <div className="label">Stan minimalny</div>
+              <div className="label">{t('inventory.minQtyLabel')}</div>
               <input type="number" min="0" className="input" value={form.minQty} onChange={e=>setForm({...form, minQty:Number(e.target.value)})}/>
             </div>
           </div>
-          <button className="btn primary" onClick={addItem} style={{marginTop:10}}>Dodaj do magazynu</button>
+          <button className="btn primary" onClick={addItem} style={{marginTop:10}}>{t('inventory.addButton')}</button>
         </div>
       </div>
 
       <div>
         <div className="card">
           <div className="body">
-            <input className="input" placeholder="Szukaj w magazynie" value={search} onChange={e=>setSearch(e.target.value)} />
+            <input className="input" placeholder={t('inventory.searchPlaceholder')} value={search} onChange={e=>setSearch(e.target.value)} />
           </div>
         </div>
 
         <div className="card" style={{marginTop:16}}>
-          <div className="header">Stan magazynu</div>
+          <div className="header">{t('inventory.tableTitle')}</div>
           <div className="body inventory-table">
             <table>
-              <thead><tr><th>Nazwa</th><th>SKU</th><th>Lokalizacja</th><th>Stan</th><th>Min</th><th>Akcje</th></tr></thead>
+              <thead><tr><th>{t('inventory.columns.name')}</th><th>{t('inventory.columns.sku')}</th><th>{t('inventory.columns.location')}</th><th>{t('inventory.columns.qty')}</th><th>{t('inventory.columns.min')}</th><th>{t('inventory.columns.actions')}</th></tr></thead>
               <tbody>
                 {shown.map(i => (
                   <tr key={i.id} className={i.qty <= i.minQty ? "low" : ""}>
@@ -81,20 +83,20 @@ export default function InventoryPanel({ db, setDb, companyId }){
                     <td>
                       <span style={{display:'inline-flex', alignItems:'center', gap:8}}>
                         {i.qty}
-                        {i.qty <= i.minQty && <span className="badge">Niski stan</span>}
+                        {i.qty <= i.minQty && <span className="badge">{t('inventory.lowStockBadge')}</span>}
                       </span>
                     </td>
                     <td>{i.minQty}</td>
                     <td>
                       <div className="row-actions">
-                        <button className="btn" onClick={()=>adjustQty(i.id, +1)}>+1</button>
-                        <button className="btn" onClick={()=>adjustQty(i.id, -1)}>-1</button>
-                        <button className="btn danger" onClick={()=>removeItem(i.id)}>Usuń</button>
+                        <button className="btn" onClick={()=>adjustQty(i.id, +1)}>{t('inventory.increment')}</button>
+                        <button className="btn" onClick={()=>adjustQty(i.id, -1)}>{t('inventory.decrement')}</button>
+                        <button className="btn danger" onClick={()=>removeItem(i.id)}>{t('inventory.remove')}</button>
                       </div>
                     </td>
                   </tr>
                 ))}
-                {shown.length===0 && <tr><td colSpan="6" style={{textAlign:'center', padding:'16px'}} className="dim">Magazyn pusty</td></tr>}
+                {shown.length===0 && <tr><td colSpan="6" style={{textAlign:'center', padding:'16px'}} className="dim">{t('inventory.empty')}</td></tr>}
               </tbody>
             </table>
           </div>

--- a/src/components/JobsPanel.jsx
+++ b/src/components/JobsPanel.jsx
@@ -1,16 +1,35 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { DEFAULT_STATUSES, JOB_TYPES, ensureUrlOrSearch, fmtPLN, isOverdue, todayISO, uid } from '../utils'
+import {
+  ensureUrlOrSearch,
+  getDefaultStatuses,
+  getDispositionLabel,
+  getDispositionOptions,
+  getJobTypes,
+  isOverdue,
+  todayISO,
+  uid,
+} from '../utils'
+import { useLanguage } from '../i18n.jsx'
 
-const DISPOSITION_LABELS = {
-  keep: 'pozostaje u mnie',
-  dispose: 'utylizacja',
-  renew: 'odnowienie',
-  return: 'odesłanie do producenta',
-}
 const DEFAULT_DISPOSITION = 'dispose'
 
 export default function JobsPanel({ db, setDb, companyId }){
-  const emptyForm = { orderNumber:"", serialNumber:"", issueDesc:"", incomingTracking:"", outgoingTracking:"", actionsDesc:"", status:"nowe", jobType:"hub", dueDate:"", shipIn:"", shipOut:"", insIn:"", insOut:"" }
+  const { t, locale, formatCurrency, formatDate, formatDateTime } = useLanguage()
+  const emptyForm = {
+    orderNumber: "",
+    serialNumber: "",
+    issueDesc: "",
+    incomingTracking: "",
+    outgoingTracking: "",
+    actionsDesc: "",
+    status: "nowe",
+    jobType: "hub",
+    dueDate: "",
+    shipIn: "",
+    shipOut: "",
+    insIn: "",
+    insOut: "",
+  }
   const [form, setForm] = useState(emptyForm)
   const [search, setSearch] = useState("")
   const [statusFilter, setStatusFilter] = useState("all")
@@ -27,22 +46,40 @@ export default function JobsPanel({ db, setDb, companyId }){
     }
   }, [usageOpen])
 
-  const jobs = useMemo(()=> db.jobs.filter(j=>j.companyId===companyId), [db, companyId])
-  const inventory = useMemo(()=> db.inventory.filter(i=>i.companyId===companyId), [db, companyId])
-  const shown = useMemo(()=>{
-    let arr=[...jobs]
-    if(statusFilter!=="all") arr=arr.filter(j=>j.status===statusFilter)
-    if(typeFilter!=="all") arr=arr.filter(j=>(j.jobType||"hub")===typeFilter)
-    if(search.trim()){
-      const q=search.toLowerCase()
-      arr=arr.filter(j => [j.orderNumber, j.serialNumber, j.issueDesc, j.actionsDesc, j.incomingTracking, j.outgoingTracking].filter(Boolean).some(v=>String(v).toLowerCase().includes(q)))
+  const statuses = useMemo(() => getDefaultStatuses(t), [t])
+  const jobTypes = useMemo(() => getJobTypes(t), [t])
+  const dispositions = useMemo(() => getDispositionOptions(t), [t])
+  const statusMap = useMemo(() => new Map(statuses.map(s => [s.value, s.label])), [statuses])
+  const jobTypeMap = useMemo(() => new Map(jobTypes.map(s => [s.value, s.label])), [jobTypes])
+  const dispositionMap = useMemo(() => new Map(dispositions.map(d => [d.value, d.label])), [dispositions])
+
+  const jobs = useMemo(() => db.jobs.filter(j => j.companyId === companyId), [db, companyId])
+  const inventory = useMemo(() => db.inventory.filter(i => i.companyId === companyId), [db, companyId])
+  const shown = useMemo(() => {
+    let arr = [...jobs]
+    if (statusFilter !== "all") arr = arr.filter(j => j.status === statusFilter)
+    if (typeFilter !== "all") arr = arr.filter(j => (j.jobType || "hub") === typeFilter)
+    if (search.trim()) {
+      const q = search.toLowerCase()
+      arr = arr.filter(j => [
+        j.orderNumber,
+        j.serialNumber,
+        j.issueDesc,
+        j.actionsDesc,
+        j.incomingTracking,
+        j.outgoingTracking,
+      ].filter(Boolean).some(v => String(v).toLowerCase().includes(q)))
     }
-    return arr.sort((a,b)=> new Date(b.createdAt)-new Date(a.createdAt))
+    return arr.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
   }, [jobs, search, statusFilter, typeFilter])
 
-  function reset(){ setForm(emptyForm); setEditId(null) }
+  function reset(){
+    setForm(emptyForm)
+    setEditId(null)
+  }
+
   function save(){
-    if(!form.orderNumber.trim()) return alert("Podaj numer zlecenia")
+    if(!form.orderNumber.trim()) return alert(t('jobs.alerts.orderNumberRequired'))
     const base = {
       companyId,
       orderNumber: form.orderNumber.trim(),
@@ -54,8 +91,10 @@ export default function JobsPanel({ db, setDb, companyId }){
       status: form.status,
       jobType: form.jobType,
       dueDate: form.dueDate || "",
-      shipIn: Number(form.shipIn||0), shipOut: Number(form.shipOut||0),
-      insIn: Number(form.insIn||0), insOut: Number(form.insOut||0),
+      shipIn: Number(form.shipIn || 0),
+      shipOut: Number(form.shipOut || 0),
+      insIn: Number(form.insIn || 0),
+      insOut: Number(form.insOut || 0),
     }
     if(editId){
       setDb({ ...db, jobs: db.jobs.map(j => j.id===editId ? { ...j, ...base, updatedAt: todayISO() } : j) })
@@ -64,24 +103,37 @@ export default function JobsPanel({ db, setDb, companyId }){
     }
     reset()
   }
+
   function edit(j){
     setEditId(j.id)
     setForm({
-      orderNumber: j.orderNumber, serialNumber: j.serialNumber, issueDesc: j.issueDesc,
-      incomingTracking: j.incomingTracking||"", outgoingTracking: j.outgoingTracking||"",
-      actionsDesc: j.actionsDesc||"", status: j.status, jobType: j.jobType||"hub",
-      dueDate: (j.dueDate||""), shipIn: String(j.shipIn??""), shipOut: String(j.shipOut??""), insIn: String(j.insIn??""), insOut: String(j.insOut??""),
+      orderNumber: j.orderNumber,
+      serialNumber: j.serialNumber,
+      issueDesc: j.issueDesc,
+      incomingTracking: j.incomingTracking || "",
+      outgoingTracking: j.outgoingTracking || "",
+      actionsDesc: j.actionsDesc || "",
+      status: j.status,
+      jobType: j.jobType || "hub",
+      dueDate: (j.dueDate || ""),
+      shipIn: String(j.shipIn ?? ""),
+      shipOut: String(j.shipOut ?? ""),
+      insIn: String(j.insIn ?? ""),
+      insOut: String(j.insOut ?? ""),
     })
   }
+
   function del(id){
-    if(!confirm("Usunąć zlecenie?")) return
+    if(!confirm(t('jobs.confirm.delete'))) return
     setDb({ ...db, jobs: db.jobs.filter(j=>j.id!==id) })
   }
+
   function openUsage(j){
     setEditId(j.id)
     setInvUsage(j.inventoryUsed||[])
     setUsageOpen(true)
   }
+
   function applyUsage(){
     const job = db.jobs.find(j=>j.id===editId)
     const before = job?.inventoryUsed||[]
@@ -118,88 +170,88 @@ export default function JobsPanel({ db, setDb, companyId }){
   return (
     <div className="layout">
       <div className="card">
-        <div className="header">{editId ? "Edytuj zlecenie" : "Nowe zlecenie"}</div>
+        <div className="header">{editId ? t('jobs.titleEdit') : t('jobs.titleNew')}</div>
         <div className="body form-stack">
           <div className="form-row">
-            <div className="label">Numer zlecenia *</div>
-            <input className="input" value={form.orderNumber} onChange={e=>setForm({...form, orderNumber:e.target.value})} placeholder="np. ZL-2025-001"/>
+            <div className="label">{t('jobs.form.orderNumberLabel')}</div>
+            <input className="input" value={form.orderNumber} onChange={e=>setForm({...form, orderNumber:e.target.value})} placeholder={t('jobs.form.orderNumberPlaceholder')}/>
           </div>
           <div className="form-row">
-            <div className="label">Numer seryjny urządzenia</div>
-            <input className="input" value={form.serialNumber} onChange={e=>setForm({...form, serialNumber:e.target.value})} placeholder="np. SN123456"/>
+            <div className="label">{t('jobs.form.serialLabel')}</div>
+            <input className="input" value={form.serialNumber} onChange={e=>setForm({...form, serialNumber:e.target.value})} placeholder={t('jobs.form.serialPlaceholder')}/>
           </div>
           <div className="form-row">
-            <div className="label">Opis usterki</div>
-            <textarea className="input" value={form.issueDesc} onChange={e=>setForm({...form, issueDesc:e.target.value})} placeholder="Co się dzieje z urządzeniem?" />
+            <div className="label">{t('jobs.form.issueLabel')}</div>
+            <textarea className="input" value={form.issueDesc} onChange={e=>setForm({...form, issueDesc:e.target.value})} placeholder={t('jobs.form.issuePlaceholder')} />
           </div>
           <div className="form-columns">
             <div className="form-row">
-              <div className="label">Tracking (przychodzący)</div>
+              <div className="label">{t('jobs.form.incomingTrackingLabel')}</div>
               <div className="form-inline">
-                <input className="input" value={form.incomingTracking} onChange={e=>setForm({...form, incomingTracking:e.target.value})} placeholder="URL lub numer listu"/>
-                <a className="btn" href={ensureUrlOrSearch(form.incomingTracking)||'#'} target="_blank" rel="noreferrer">Otwórz</a>
+                <input className="input" value={form.incomingTracking} onChange={e=>setForm({...form, incomingTracking:e.target.value})} placeholder={t('jobs.form.trackingPlaceholder')}/>
+                <a className="btn" href={ensureUrlOrSearch(form.incomingTracking)||'#'} target="_blank" rel="noreferrer">{t('jobs.form.openLink')}</a>
               </div>
             </div>
             <div className="form-row">
-              <div className="label">Tracking (wychodzący)</div>
+              <div className="label">{t('jobs.form.outgoingTrackingLabel')}</div>
               <div className="form-inline">
-                <input className="input" value={form.outgoingTracking} onChange={e=>setForm({...form, outgoingTracking:e.target.value})} placeholder="URL lub numer listu"/>
-                <a className="btn" href={ensureUrlOrSearch(form.outgoingTracking)||'#'} target="_blank" rel="noreferrer">Otwórz</a>
+                <input className="input" value={form.outgoingTracking} onChange={e=>setForm({...form, outgoingTracking:e.target.value})} placeholder={t('jobs.form.trackingPlaceholder')}/>
+                <a className="btn" href={ensureUrlOrSearch(form.outgoingTracking)||'#'} target="_blank" rel="noreferrer">{t('jobs.form.openLink')}</a>
               </div>
             </div>
           </div>
           <div className="form-row">
-            <div className="label">Opis czynności wykonanych</div>
-            <textarea className="input" value={form.actionsDesc} onChange={e=>setForm({...form, actionsDesc:e.target.value})} placeholder="Co zostało zrobione?" />
+            <div className="label">{t('jobs.form.actionsLabel')}</div>
+            <textarea className="input" value={form.actionsDesc} onChange={e=>setForm({...form, actionsDesc:e.target.value})} placeholder={t('jobs.form.actionsPlaceholder')} />
           </div>
           <div className="form-columns">
             <div className="form-row">
-              <div className="label">Status</div>
+              <div className="label">{t('jobs.form.statusLabel')}</div>
               <select className="input" value={form.status} onChange={e=>setForm({...form, status:e.target.value})}>
-                {DEFAULT_STATUSES.map(s => <option key={s.value} value={s.value}>{s.label}</option>)}
+                {statuses.map(s => <option key={s.value} value={s.value}>{s.label}</option>)}
               </select>
             </div>
             <div className="form-row">
-              <div className="label">Typ zlecenia</div>
+              <div className="label">{t('jobs.form.typeLabel')}</div>
               <select className="input" value={form.jobType} onChange={e=>setForm({...form, jobType:e.target.value})}>
-                {JOB_TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
+                {jobTypes.map(tpl => <option key={tpl.value} value={tpl.value}>{tpl.label}</option>)}
               </select>
             </div>
           </div>
           <div className="form-row">
-            <div className="label">Termin (SLA)</div>
+            <div className="label">{t('jobs.form.dueDateLabel')}</div>
             <input type="date" className="input" value={form.dueDate} onChange={e=>setForm({...form, dueDate:e.target.value})} />
           </div>
           <div className="form-section">
-            <div className="form-section-title">Koszty przesyłki i ubezpieczenia (PLN)</div>
+            <div className="form-section-title">{t('jobs.form.shipmentsTitle')}</div>
             <div className="form-columns">
               <div className="form-stack">
-                <div className="form-section-caption muted">PRZYCHODZĄCA (IN)</div>
+                <div className="form-section-caption muted">{t('jobs.form.shipmentsInCaption')}</div>
                 <div className="form-row">
-                  <div className="label">Koszt przesyłki (IN)</div>
-                  <input type="number" min="0" step="0.01" className="input" value={form.shipIn} onChange={e=>setForm({...form, shipIn:e.target.value})} placeholder="np. 85.00" />
+                  <div className="label">{t('jobs.form.shipInLabel')}</div>
+                  <input type="number" min="0" step="0.01" className="input" value={form.shipIn} onChange={e=>setForm({...form, shipIn:e.target.value})} placeholder={t('jobs.form.shipPlaceholder')} />
                 </div>
                 <div className="form-row">
-                  <div className="label">Ubezpieczenie (IN)</div>
-                  <input type="number" min="0" step="0.01" className="input" value={form.insIn} onChange={e=>setForm({...form, insIn:e.target.value})} placeholder="np. 12.00" />
+                  <div className="label">{t('jobs.form.insuranceInLabel')}</div>
+                  <input type="number" min="0" step="0.01" className="input" value={form.insIn} onChange={e=>setForm({...form, insIn:e.target.value})} placeholder={t('jobs.form.insurancePlaceholder')} />
                 </div>
               </div>
               <div className="form-stack">
-                <div className="form-section-caption muted">WYCHODZĄCA (OUT)</div>
+                <div className="form-section-caption muted">{t('jobs.form.shipmentsOutCaption')}</div>
                 <div className="form-row">
-                  <div className="label">Koszt przesyłki (OUT)</div>
-                  <input type="number" min="0" step="0.01" className="input" value={form.shipOut} onChange={e=>setForm({...form, shipOut:e.target.value})} placeholder="np. 95.00" />
+                  <div className="label">{t('jobs.form.shipOutLabel')}</div>
+                  <input type="number" min="0" step="0.01" className="input" value={form.shipOut} onChange={e=>setForm({...form, shipOut:e.target.value})} placeholder={t('jobs.form.shipPlaceholder')} />
                 </div>
                 <div className="form-row">
-                  <div className="label">Ubezpieczenie (OUT)</div>
-                  <input type="number" min="0" step="0.01" className="input" value={form.insOut} onChange={e=>setForm({...form, insOut:e.target.value})} placeholder="np. 15.00" />
+                  <div className="label">{t('jobs.form.insuranceOutLabel')}</div>
+                  <input type="number" min="0" step="0.01" className="input" value={form.insOut} onChange={e=>setForm({...form, insOut:e.target.value})} placeholder={t('jobs.form.insurancePlaceholder')} />
                 </div>
               </div>
             </div>
           </div>
           <div className="form-actions">
-            <button className="btn primary" onClick={save}>{editId ? "Zapisz zmiany" : "Dodaj zlecenie"}</button>
-            {editId && <button className="btn" onClick={reset}>Anuluj</button>}
+            <button className="btn primary" onClick={save}>{editId ? t('jobs.form.saveButton') : t('jobs.form.addButton')}</button>
+            {editId && <button className="btn" onClick={reset}>{t('jobs.form.cancelButton')}</button>}
           </div>
         </div>
       </div>
@@ -208,26 +260,32 @@ export default function JobsPanel({ db, setDb, companyId }){
         <div className="card">
           <div className="body filter-bar">
             <div className="filter-bar__search">
-              <input className="input" placeholder="Szukaj (nr, SN, opis...)" value={search} onChange={e=>setSearch(e.target.value)} />
+              <input className="input" placeholder={t('jobs.filters.searchPlaceholder')} value={search} onChange={e=>setSearch(e.target.value)} />
             </div>
             <select className="input" value={statusFilter} onChange={e=>setStatusFilter(e.target.value)}>
-              <option value="all">Wszystkie statusy</option>
-              {DEFAULT_STATUSES.map(s => <option key={s.value} value={s.value}>{s.label}</option>)}
+              <option value="all">{t('jobs.filters.statusAll')}</option>
+              {statuses.map(s => <option key={s.value} value={s.value}>{s.label}</option>)}
             </select>
             <select className="input" value={typeFilter} onChange={e=>setTypeFilter(e.target.value)}>
-              <option value="all">Wszystkie typy</option>
-              {JOB_TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
+              <option value="all">{t('jobs.filters.typeAll')}</option>
+              {jobTypes.map(tpl => <option key={tpl.value} value={tpl.value}>{tpl.label}</option>)}
             </select>
           </div>
         </div>
 
         <div className="card" style={{marginTop:16}}>
-          <div className="header">Lista zleceń</div>
+          <div className="header">{t('jobs.list.title')}</div>
           <div className="body" style={{overflowX:'auto'}}>
             <table>
               <thead>
                 <tr>
-                  <th>Numer</th><th>SN</th><th>Typ</th><th>SLA</th><th>Status</th><th>Utworzono</th><th>Akcje</th>
+                  <th>{t('jobs.list.columns.number')}</th>
+                  <th>{t('jobs.list.columns.serial')}</th>
+                  <th>{t('jobs.list.columns.type')}</th>
+                  <th>{t('jobs.list.columns.sla')}</th>
+                  <th>{t('jobs.list.columns.status')}</th>
+                  <th>{t('jobs.list.columns.createdAt')}</th>
+                  <th>{t('jobs.list.columns.actions')}</th>
                 </tr>
               </thead>
               <tbody>
@@ -236,26 +294,26 @@ export default function JobsPanel({ db, setDb, companyId }){
                     <tr>
                       <td style={{fontWeight:600}}>{j.orderNumber}</td>
                       <td>{j.serialNumber}</td>
-                      <td><span className="badge">{JOB_TYPES.find(t=>t.value===j.jobType)?.label || j.jobType}</span></td>
-                      <td>{j.dueDate ? <span className={isOverdue(j.dueDate) && !["zakonczone","odeslane"].includes(j.status) ? "danger-text":""}>{new Date(j.dueDate).toLocaleDateString()}</span> : "—"}</td>
-                      <td>{DEFAULT_STATUSES.find(s=>s.value===j.status)?.label || j.status}</td>
-                      <td>{new Date(j.createdAt).toLocaleString()}</td>
+                      <td><span className="badge">{jobTypeMap.get(j.jobType || 'hub') || j.jobType}</span></td>
+                      <td>{j.dueDate ? <span className={isOverdue(j.dueDate) && !["zakonczone","odeslane"].includes(j.status) ? 'danger-text' : ''}>{formatDate(j.dueDate) || '—'}</span> : '—'}</td>
+                      <td>{statusMap.get(j.status) || j.status}</td>
+                      <td>{formatDateTime(j.createdAt) || new Date(j.createdAt).toLocaleString(locale)}</td>
                       <td>
                         <div className="row-actions">
-                          <button className="btn" onClick={()=>edit(j)}>Edytuj</button>
-                          <button className="btn" onClick={()=>openUsage(j)}>Części</button>
-                          <button className="btn danger" onClick={()=>del(j.id)}>Usuń</button>
+                          <button className="btn" onClick={()=>edit(j)}>{t('jobs.list.actionEdit')}</button>
+                          <button className="btn" onClick={()=>openUsage(j)}>{t('jobs.list.actionParts')}</button>
+                          <button className="btn danger" onClick={()=>del(j.id)}>{t('jobs.list.actionDelete')}</button>
                         </div>
                       </td>
                     </tr>
                     <tr>
                       <td colSpan={7}>
-                        <JobDetails job={j} total={totalShip(j)} />
+                        <JobDetails job={j} total={totalShip(j)} jobTypeMap={jobTypeMap} dispositionMap={dispositionMap} />
                       </td>
                     </tr>
                   </React.Fragment>
                 ))}
-                {shown.length===0 && <tr><td colSpan="7" style={{textAlign:'center', padding:'16px', color:'#64748b'}}>Brak zleceń spełniających kryteria</td></tr>}
+                {shown.length===0 && <tr><td colSpan="7" style={{textAlign:'center', padding:'16px', color:'#64748b'}}>{t('jobs.list.empty')}</td></tr>}
               </tbody>
             </table>
           </div>
@@ -276,12 +334,12 @@ export default function JobsPanel({ db, setDb, companyId }){
           }}
         >
           <div className="card" style={{ maxWidth: 720, width: '100%' }}>
-            <div className="header">Zużycie części</div>
+            <div className="header">{t('jobs.usageModal.title')}</div>
             <div className="body">
-              <InventoryUsageEditor usage={invUsage} setUsage={setInvUsage} inventory={inventory} />
+              <InventoryUsageEditor usage={invUsage} setUsage={setInvUsage} inventory={inventory} dispositions={dispositions} dispositionMap={dispositionMap} />
               <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 12 }}>
-                <button className="btn primary" onClick={applyUsage}>Zapisz i zaktualizuj magazyn</button>
-                <button className="btn" onClick={() => { setUsageOpen(false); setEditId(null); }}>Anuluj</button>
+                <button className="btn primary" onClick={applyUsage}>{t('jobs.usageModal.apply')}</button>
+                <button className="btn" onClick={() => { setUsageOpen(false); setEditId(null); }}>{t('jobs.usageModal.cancel')}</button>
               </div>
             </div>
           </div>
@@ -291,47 +349,64 @@ export default function JobsPanel({ db, setDb, companyId }){
   )
 }
 
-function JobDetails({ job, total }){
+function JobDetails({ job, total, jobTypeMap, dispositionMap }){
+  const { t, formatCurrency, formatDate, formatDateTime } = useLanguage()
+  const typeLabel = jobTypeMap.get(job.jobType || 'hub') || job.jobType
+  const dueDate = job.dueDate ? (formatDate(job.dueDate) || formatDate(new Date(job.dueDate))) : '—'
+  const updated = formatDateTime(job.updatedAt || job.createdAt)
+  const shipmentTotal = formatCurrency(total || 0)
+  const inboundShip = formatCurrency(Number(job.shipIn||0))
+  const outboundShip = formatCurrency(Number(job.shipOut||0))
+  const inboundIns = formatCurrency(Number(job.insIn||0))
+  const outboundIns = formatCurrency(Number(job.insOut||0))
+
   return (
     <div style={{marginTop:8, background:'#f1f5f9', borderRadius:12, padding:12, fontSize:12, color:'#334155'}}>
       <div className="grid col-2">
         <div>
-          <div><strong>SN:</strong> {job.serialNumber || "—"}</div>
-          <div><strong>Usterka:</strong> {job.issueDesc || "—"}</div>
-          <div><strong>Czynności:</strong> {job.actionsDesc || "—"}</div>
-          <div><strong>Typ:</strong> {JOB_TYPES.find(t=>t.value===job.jobType)?.label || job.jobType}</div>
-          <div><strong>Termin (SLA):</strong> {job.dueDate ? new Date(job.dueDate).toLocaleDateString() : "—"}</div>
+          <div><strong>{t('jobs.details.serial')}</strong> {job.serialNumber || '—'}</div>
+          <div><strong>{t('jobs.details.issue')}</strong> {job.issueDesc || '—'}</div>
+          <div><strong>{t('jobs.details.actions')}</strong> {job.actionsDesc || '—'}</div>
+          <div><strong>{t('jobs.details.type')}</strong> {typeLabel}</div>
+          <div><strong>{t('jobs.details.sla')}</strong> {dueDate}</div>
         </div>
         <div>
-          <div><strong>Tracking IN:</strong> {job.incomingTracking || "—"}</div>
-          <div><strong>Tracking OUT:</strong> {job.outgoingTracking || "—"}</div>
-          <div><strong>Ostatnia zmiana:</strong> {new Date(job.updatedAt || job.createdAt).toLocaleString()}</div>
-          <div style={{marginTop:4}}><strong>Koszty przesyłek:</strong> {fmtPLN(total || 0)}</div>
+          <div><strong>{t('jobs.details.trackingIn')}</strong> {job.incomingTracking || '—'}</div>
+          <div><strong>{t('jobs.details.trackingOut')}</strong> {job.outgoingTracking || '—'}</div>
+          <div><strong>{t('jobs.details.updatedAt')}</strong> {updated || '—'}</div>
+          <div style={{marginTop:4}}><strong>{t('jobs.details.shipmentCosts')}</strong> {shipmentTotal}</div>
           <div className="grid" style={{gridTemplateColumns:'1fr 1fr', gap:4, marginTop:4}}>
-            <div>IN: {fmtPLN(Number(job.shipIn||0))} • Ubezp: {fmtPLN(Number(job.insIn||0))}</div>
-            <div>OUT: {fmtPLN(Number(job.shipOut||0))} • Ubezp: {fmtPLN(Number(job.insOut||0))}</div>
+            <div>{t('jobs.details.inboundLabel')}: {inboundShip} • {t('jobs.details.insuranceShort')}: {inboundIns}</div>
+            <div>{t('jobs.details.outboundLabel')}: {outboundShip} • {t('jobs.details.insuranceShort')}: {outboundIns}</div>
           </div>
         </div>
       </div>
       <div style={{borderTop:'1px solid #e2e8f0', margin:'8px 0'}}></div>
-      <div style={{fontWeight:600, marginBottom:4}}>Zużyte części:</div>
+      <div style={{fontWeight:600, marginBottom:4}}>{t('jobs.details.usageTitle')}</div>
       {(!job.inventoryUsed || job.inventoryUsed.length===0) ? (
-        <div className="dim">Brak</div>
+        <div className="dim">{t('jobs.details.noUsage')}</div>
       ) : (
         <ul style={{paddingLeft:18, margin:0}}>
-          {job.inventoryUsed.map((u, idx) => (
-            <li key={idx}>{u.name} (SKU: {u.sku}) — {u.qty} szt. — los: {DISPOSITION_LABELS[u.disposition] || u.disposition}</li>
-          ))}
+          {job.inventoryUsed.map((u, idx) => {
+            const label = dispositionMap.get(u.disposition) || getDispositionLabel(u.disposition, t)
+            return (
+              <li key={idx}>
+                {u.name} (SKU: {u.sku}) — {t('jobs.details.quantityWithUnit', { qty: u.qty })} — {t('jobs.details.dispositionPrefix', { label })}
+              </li>
+            )
+          })}
         </ul>
       )}
     </div>
   )
 }
 
-function InventoryUsageEditor({ usage, setUsage, inventory }){
+function InventoryUsageEditor({ usage, setUsage, inventory, dispositions, dispositionMap }){
+  const { t } = useLanguage()
   const [itemId, setItemId] = useState("")
   const [qty, setQty] = useState(1)
   const [disp, setDisp] = useState(DEFAULT_DISPOSITION)
+
   function add(){
     if(!itemId || qty<1 || !disp) return
     const item = inventory.find(i=>i.id===itemId)
@@ -341,46 +416,75 @@ function InventoryUsageEditor({ usage, setUsage, inventory }){
       if(ex) return prev.map(u => (u.itemId===itemId && u.disposition===disp) ? { ...u, qty: u.qty + qty } : u)
       return [...prev, { itemId, sku:item.sku, name:item.name, qty, disposition: disp }]
     })
-    setItemId(""); setQty(1); setDisp(DEFAULT_DISPOSITION)
+    setItemId("")
+    setQty(1)
+    setDisp(DEFAULT_DISPOSITION)
   }
-  function removeLine(id, d){ setUsage(usage.filter(u => !(u.itemId===id && u.disposition===d))) }
+
+  function removeLine(id, d){
+    setUsage(usage.filter(u => !(u.itemId===id && u.disposition===d)))
+  }
+
   return (
     <div>
       <div className="grid" style={{gridTemplateColumns:'1fr 120px 220px 120px', gap:12, alignItems:'end'}}>
         <div>
-          <div className="label">Pozycja z magazynu</div>
+          <div className="label">{t('jobs.usageModal.selectorLabel')}</div>
           <select className="input" value={itemId} onChange={e=>setItemId(e.target.value)}>
-            <option value="">— wybierz —</option>
-            {inventory.map(i => <option key={i.id} value={i.id}>{i.name} (SKU: {i.sku}) — dostępne: {i.qty}</option>)}
+            <option value="">{t('jobs.usageModal.selectorPlaceholder')}</option>
+            {inventory.map(i => (
+              <option key={i.id} value={i.id}>
+                {t('jobs.usageModal.inventoryOption', { name: i.name, sku: i.sku, qty: i.qty })}
+              </option>
+            ))}
           </select>
         </div>
         <div>
-          <div className="label">Ilość</div>
-          <input type="number" min="1" className="input" value={qty} onChange={e=>setQty(parseInt(e.target.value||"1"))}/>
+          <div className="label">{t('jobs.usageModal.quantityLabel')}</div>
+          <input
+            type="number"
+            min="1"
+            className="input"
+            value={qty}
+            onChange={e => {
+              const next = parseInt(e.target.value || '1', 10)
+              setQty(Number.isNaN(next) ? 1 : Math.max(1, next))
+            }}
+          />
         </div>
         <div>
-          <div className="label">Los części</div>
+          <div className="label">{t('jobs.usageModal.dispositionLabel')}</div>
           <select className="input" value={disp} onChange={e=>setDisp(e.target.value)}>
-            <option value="dispose">Utylizacja</option>
-            <option value="renew">Odnowienie</option>
-            <option value="return">Odesłanie do producenta</option>
-            <option value="keep">Pozostaje u mnie</option>
+            {dispositions.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
           </select>
         </div>
-        <div><button className="btn primary" onClick={add} style={{width:'100%'}} disabled={!itemId || qty<1 || !disp}>Dodaj</button></div>
+        <div>
+          <button className="btn primary" onClick={add} style={{width:'100%'}} disabled={!itemId || qty<1 || !disp}>{t('jobs.usageModal.addButton')}</button>
+        </div>
       </div>
 
       <div className="card" style={{marginTop:12}}>
         <div className="body" style={{overflowX:'auto'}}>
           <table>
-            <thead><tr><th>Nazwa</th><th>SKU</th><th>Ilość</th><th>Los</th><th></th></tr></thead>
+            <thead>
+              <tr>
+                <th>{t('jobs.usageModal.tableHeaders.name')}</th>
+                <th>{t('jobs.usageModal.tableHeaders.sku')}</th>
+                <th>{t('jobs.usageModal.tableHeaders.qty')}</th>
+                <th>{t('jobs.usageModal.tableHeaders.disposition')}</th>
+                <th>{t('jobs.usageModal.tableHeaders.actions')}</th>
+              </tr>
+            </thead>
             <tbody>
               {usage.length===0 ? (
-                <tr><td colSpan="5" style={{textAlign:'center', padding:'12px'}} className="dim">Nic nie dodano</td></tr>
+                <tr><td colSpan="5" style={{textAlign:'center', padding:'12px'}} className="dim">{t('jobs.usageModal.empty')}</td></tr>
               ) : usage.map((u, idx) => (
                 <tr key={idx}>
-                  <td>{u.name}</td><td>{u.sku}</td><td>{u.qty}</td><td>{DISPOSITION_LABELS[u.disposition] || u.disposition}</td>
-                  <td style={{textAlign:'right'}}><button className="btn ghost" onClick={()=>removeLine(u.itemId, u.disposition)}>Usuń</button></td>
+                  <td>{u.name}</td>
+                  <td>{u.sku}</td>
+                  <td>{u.qty}</td>
+                  <td>{dispositionMap.get(u.disposition) || getDispositionLabel(u.disposition, t)}</td>
+                  <td style={{textAlign:'right'}}><button className="btn ghost" onClick={()=>removeLine(u.itemId, u.disposition)}>{t('jobs.usageModal.remove')}</button></td>
                 </tr>
               ))}
             </tbody>
@@ -390,3 +494,4 @@ function InventoryUsageEditor({ usage, setUsage, inventory }){
     </div>
   )
 }
+

--- a/src/components/RepairQueuePanel.jsx
+++ b/src/components/RepairQueuePanel.jsx
@@ -1,12 +1,6 @@
 import React, { useMemo } from 'react'
-import { todayISO, uid } from '../utils'
-
-const DISPOSITION_LABELS = {
-  keep: 'pozostaje u mnie',
-  dispose: 'utylizacja',
-  renew: 'odnowienie',
-  return: 'odesłanie do producenta',
-}
+import { getDispositionLabel, todayISO, uid } from '../utils'
+import { useLanguage } from '../i18n.jsx'
 
 const DISPOSITION_ACTIONS = {
   renew: ['ok', 'bad'],
@@ -14,6 +8,7 @@ const DISPOSITION_ACTIONS = {
 }
 
 export default function RepairQueuePanel({ db, setDb, companyId }){
+  const { t, formatDateTime } = useLanguage()
   const repairQueue = useMemo(() => db.repairQueue.filter(r => r.companyId === companyId), [db, companyId])
   const jobMap = useMemo(() => {
     const map = new Map()
@@ -74,23 +69,23 @@ export default function RepairQueuePanel({ db, setDb, companyId }){
 
   return (
     <div className="card">
-      <div className="header">Kolejka części</div>
+      <div className="header">{t('repairQueue.title')}</div>
       <div className="body inventory-table">
         <table>
           <thead>
             <tr>
-              <th>Data</th>
-              <th>Zlecenie</th>
-              <th>Część</th>
-              <th>SKU</th>
-              <th>Ilość</th>
-              <th>Los</th>
-              <th>Akcje</th>
+              <th>{t('repairQueue.columns.date')}</th>
+              <th>{t('repairQueue.columns.job')}</th>
+              <th>{t('repairQueue.columns.part')}</th>
+              <th>{t('repairQueue.columns.sku')}</th>
+              <th>{t('repairQueue.columns.qty')}</th>
+              <th>{t('repairQueue.columns.disposition')}</th>
+              <th>{t('repairQueue.columns.actions')}</th>
             </tr>
           </thead>
           <tbody>
             {repairQueue.length===0 ? (
-              <tr><td colSpan={7} style={{textAlign:'center', padding:'16px'}} className="dim">Kolejka pusta</td></tr>
+              <tr><td colSpan={7} style={{textAlign:'center', padding:'16px'}} className="dim">{t('repairQueue.empty')}</td></tr>
             ) : repairQueue
               .slice()
               .sort((a,b)=> new Date(b.createdAt||0) - new Date(a.createdAt||0))
@@ -98,22 +93,22 @@ export default function RepairQueuePanel({ db, setDb, companyId }){
                 const job = jobMap.get(item.jobId)
                 return (
                   <tr key={item.id}>
-                    <td>{item.createdAt ? new Date(item.createdAt).toLocaleString() : '—'}</td>
+                    <td>{item.createdAt ? (formatDateTime(item.createdAt) || new Date(item.createdAt).toLocaleString()) : '—'}</td>
                     <td>{job ? job.orderNumber : '—'}</td>
                     <td>{item.name}</td>
                     <td>{item.sku}</td>
                     <td>{item.qty}</td>
-                    <td>{DISPOSITION_LABELS[item.disposition] || item.disposition}</td>
+                    <td>{getDispositionLabel(item.disposition, t)}</td>
                     <td>
                       <div className="row-actions">
                         {item.disposition === 'renew' && (
                           <>
-                            <button className="btn" onClick={()=>queueOk(item.id)} disabled={!item.itemId}>OK</button>
-                            <button className="btn danger" onClick={()=>queueBad(item.id)}>BAD</button>
+                            <button className="btn" onClick={()=>queueOk(item.id)} disabled={!item.itemId}>{t('repairQueue.actions.ok')}</button>
+                            <button className="btn danger" onClick={()=>queueBad(item.id)}>{t('repairQueue.actions.bad')}</button>
                           </>
                         )}
                         {item.disposition === 'return' && (
-                          <button className="btn" onClick={()=>queueReturn(item.id)}>Odesłano</button>
+                          <button className="btn" onClick={()=>queueReturn(item.id)}>{t('repairQueue.actions.return')}</button>
                         )}
                       </div>
                     </td>

--- a/src/i18n.jsx
+++ b/src/i18n.jsx
@@ -1,0 +1,683 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+
+const LANGUAGE_STORAGE_KEY = 'supporthub-language'
+const DEFAULT_LANGUAGE = 'pl'
+
+export const translations = {
+  pl: {
+    meta: { locale: 'pl-PL', currency: 'PLN' },
+    common: {
+      languageNames: { pl: 'Polski', en: 'English' },
+      languageShort: { pl: 'PL', en: 'EN' },
+      statuses: {
+        nowe: 'Nowe',
+        wtrakcie: 'W trakcie',
+        czeka: 'Czeka na części',
+        zakonczone: 'Zakończone',
+        odeslane: 'Odesłane',
+      },
+      jobTypes: {
+        hub: 'Naprawa w hubie',
+        onsite: 'Naprawa u klienta',
+        upgrade: 'Upgrade',
+      },
+      dispositions: {
+        keep: 'pozostaje u mnie',
+        dispose: 'utylizacja',
+        renew: 'odnowienie',
+        return: 'odesłanie do producenta',
+      },
+    },
+    app: {
+      title: 'Serwis Manager',
+      subtitle: 'Zlecenia • Magazyn • Raporty',
+      tabs: { jobs: 'Zlecenia', inventory: 'Magazyn', reports: 'Raport' },
+      footerNotice: 'Dane lokalnie w przeglądarce. Import/Export = kopia/przenoszenie.',
+      languageToggle: {
+        button: 'PL / EN',
+        aria: 'Zmień język na {{language}}',
+      },
+    },
+    emptyState: {
+      title: 'Zacznij od dodania firmy',
+      description: 'Aplikacja gotowa do pracy. Dodaj firmę, a potem twórz zlecenia i zarządzaj magazynem.',
+      loadDemo: 'Wczytaj dane przykładowe',
+    },
+    companySwitcher: {
+      button: 'Firmy ▾',
+      manage: 'Zarządzaj',
+      nameLabel: 'Nazwa firmy',
+      placeholder: 'np. ACME Sp. z o.o.',
+      add: 'Dodaj',
+      removeCurrent: 'Usuń bieżącą',
+      confirmDelete: 'Usunąć bieżącą firmę? Z danymi!',
+    },
+    importExport: {
+      import: 'Import',
+      export: 'Eksport',
+      importSuccess: 'Dane zaimportowane',
+      invalidFile: 'Nieprawidłowy plik',
+      importError: 'Błąd importu: {{error}}',
+      fileNamePrefix: 'serwis-manager-backup',
+    },
+    jobs: {
+      titleNew: 'Nowe zlecenie',
+      titleEdit: 'Edytuj zlecenie',
+      form: {
+        orderNumberLabel: 'Numer zlecenia *',
+        orderNumberPlaceholder: 'np. ZL-2025-001',
+        serialLabel: 'Numer seryjny urządzenia',
+        serialPlaceholder: 'np. SN123456',
+        issueLabel: 'Opis usterki',
+        issuePlaceholder: 'Co się dzieje z urządzeniem?',
+        incomingTrackingLabel: 'Tracking (przychodzący)',
+        outgoingTrackingLabel: 'Tracking (wychodzący)',
+        trackingPlaceholder: 'URL lub numer listu',
+        actionsLabel: 'Opis czynności wykonanych',
+        actionsPlaceholder: 'Co zostało zrobione?',
+        statusLabel: 'Status',
+        typeLabel: 'Typ zlecenia',
+        dueDateLabel: 'Termin (SLA)',
+        shipmentsTitle: 'Koszty przesyłki i ubezpieczenia (PLN)',
+        shipmentsInCaption: 'PRZYCHODZĄCA (IN)',
+        shipmentsOutCaption: 'WYCHODZĄCA (OUT)',
+        shipInLabel: 'Koszt przesyłki (IN)',
+        shipOutLabel: 'Koszt przesyłki (OUT)',
+        insuranceInLabel: 'Ubezpieczenie (IN)',
+        insuranceOutLabel: 'Ubezpieczenie (OUT)',
+        shipPlaceholder: 'np. 85.00',
+        insurancePlaceholder: 'np. 12.00',
+        openLink: 'Otwórz',
+        saveButton: 'Zapisz zmiany',
+        addButton: 'Dodaj zlecenie',
+        cancelButton: 'Anuluj',
+      },
+      filters: {
+        searchPlaceholder: 'Szukaj (nr, SN, opis...)',
+        statusAll: 'Wszystkie statusy',
+        typeAll: 'Wszystkie typy',
+      },
+      list: {
+        title: 'Lista zleceń',
+        columns: {
+          number: 'Numer',
+          serial: 'SN',
+          type: 'Typ',
+          sla: 'SLA',
+          status: 'Status',
+          createdAt: 'Utworzono',
+          actions: 'Akcje',
+        },
+        actionEdit: 'Edytuj',
+        actionParts: 'Części',
+        actionDelete: 'Usuń',
+        empty: 'Brak zleceń spełniających kryteria',
+      },
+      details: {
+        serial: 'SN:',
+        issue: 'Usterka:',
+        actions: 'Czynności:',
+        type: 'Typ:',
+        sla: 'Termin (SLA):',
+        trackingIn: 'Tracking IN:',
+        trackingOut: 'Tracking OUT:',
+        updatedAt: 'Ostatnia zmiana:',
+        shipmentCosts: 'Koszty przesyłek:',
+        inboundLabel: 'IN',
+        outboundLabel: 'OUT',
+        insuranceShort: 'Ubezp',
+        usageTitle: 'Zużyte części:',
+        noUsage: 'Brak',
+        dispositionPrefix: 'los: {{label}}',
+        quantityWithUnit: '{{qty}} szt.',
+      },
+      usageModal: {
+        title: 'Zużycie części',
+        selectorLabel: 'Pozycja z magazynu',
+        selectorPlaceholder: '— wybierz —',
+        quantityLabel: 'Ilość',
+        dispositionLabel: 'Los części',
+        addButton: 'Dodaj',
+        tableHeaders: {
+          name: 'Nazwa',
+          sku: 'SKU',
+          qty: 'Ilość',
+          disposition: 'Los',
+          actions: '',
+        },
+        empty: 'Nic nie dodano',
+        remove: 'Usuń',
+        apply: 'Zapisz i zaktualizuj magazyn',
+        cancel: 'Anuluj',
+        inventoryOption: '{{name}} (SKU: {{sku}}) — dostępne: {{qty}}',
+      },
+      alerts: {
+        orderNumberRequired: 'Podaj numer zlecenia',
+      },
+      confirm: {
+        delete: 'Usunąć zlecenie?',
+      },
+    },
+    inventory: {
+      formTitle: 'Dodaj pozycję',
+      nameLabel: 'Nazwa *',
+      namePlaceholder: 'np. Moduł A / Kondensator 100uF',
+      skuLabel: 'SKU / indeks',
+      skuPlaceholder: 'np. KND-100',
+      qtyLabel: 'Ilość początkowa',
+      locationLabel: 'Lokalizacja',
+      locationPlaceholder: 'np. Regał A3',
+      minQtyLabel: 'Stan minimalny',
+      addButton: 'Dodaj do magazynu',
+      searchPlaceholder: 'Szukaj w magazynie',
+      tableTitle: 'Stan magazynu',
+      columns: {
+        name: 'Nazwa',
+        sku: 'SKU',
+        location: 'Lokalizacja',
+        qty: 'Stan',
+        min: 'Min',
+        actions: 'Akcje',
+      },
+      lowStockBadge: 'Niski stan',
+      empty: 'Magazyn pusty',
+      increment: '+1',
+      decrement: '-1',
+      remove: 'Usuń',
+      alerts: {
+        nameRequired: 'Podaj nazwę pozycji',
+      },
+      confirm: {
+        delete: 'Usunąć pozycję z magazynu?',
+      },
+    },
+    repairQueue: {
+      title: 'Kolejka części',
+      columns: {
+        date: 'Data',
+        job: 'Zlecenie',
+        part: 'Część',
+        sku: 'SKU',
+        qty: 'Ilość',
+        disposition: 'Los',
+        actions: 'Akcje',
+      },
+      empty: 'Kolejka pusta',
+      actions: {
+        ok: 'OK',
+        bad: 'BAD',
+        return: 'Odesłano',
+      },
+    },
+    reports: {
+      dateRangeTitle: 'Zakres dat',
+      fromLabel: 'Od',
+      toLabel: 'Do',
+      jobsSummaryTitle: 'Podsumowanie zleceń',
+      jobsSummary: {
+        totalPrefix: 'Łącznie (w zakresie):',
+      },
+      partsSummaryTitle: 'Podsumowanie części',
+      partsSummary: {
+        totalPrefix: 'Łącznie użytych (szt.):',
+        keptLabel: 'Pozostały u mnie',
+        disposedLabel: 'Utylizacja',
+        disposalEventsLabel: 'Utylizacje',
+        returnEventsLabel: 'Odesłania',
+        renewEventsLabel: 'Odnowienia (liczba pozycji)',
+      },
+      shipmentsTitle: 'Koszty przesyłek (PLN)',
+      shipments: {
+        shipmentLabel: 'Przesyłka',
+        insuranceLabel: 'Ubezpieczenie',
+        totalLabel: 'Razem:',
+      },
+      modal: {
+        noResults: 'Brak wyników',
+        close: 'Zamknij',
+        jobsTitle: 'Zlecenia — {{label}}',
+        partsTitle: 'Części — {{label}}',
+        jobStatusPrefix: 'Status: {{status}}',
+        jobTypePrefix: 'Typ: {{type}}',
+        jobCreatedAt: 'Utworzono: {{date}}',
+        jobFallbackTitle: 'Zlecenie {{id}}',
+        partQty: 'Ilość: {{qty}}',
+        partDisposition: 'Los: {{label}}',
+        partJob: 'Zlecenie: {{job}}',
+        partDate: 'Data: {{date}}',
+        partUnknown: 'Nieznana część',
+        jobNoStatus: 'Brak statusu',
+        jobNoDate: 'Brak daty',
+      },
+    },
+    demo: {
+      companies: {
+        first: 'Firma A',
+        second: 'Firma B',
+      },
+      jobs: {
+        first: {
+          orderNumber: 'ZL-2025-001',
+          serialNumber: 'SN12345',
+          issue: 'Nie włącza się',
+          actions: 'Diagnoza zasilania',
+        },
+        second: {
+          orderNumber: 'ZL-2025-002',
+          serialNumber: 'SN55555',
+          issue: 'Brak obrazu',
+          actions: 'Wymiana kondensatora',
+        },
+      },
+      inventory: {
+        capacitor: 'Kondensator 100uF',
+        psu: 'Zasilacz 12V',
+      },
+    },
+  },
+  en: {
+    meta: { locale: 'en-US', currency: 'PLN' },
+    common: {
+      languageNames: { pl: 'Polish', en: 'English' },
+      languageShort: { pl: 'PL', en: 'EN' },
+      statuses: {
+        nowe: 'New',
+        wtrakcie: 'In progress',
+        czeka: 'Waiting for parts',
+        zakonczone: 'Completed',
+        odeslane: 'Shipped back',
+      },
+      jobTypes: {
+        hub: 'Hub repair',
+        onsite: 'On-site repair',
+        upgrade: 'Upgrade',
+      },
+      dispositions: {
+        keep: 'kept on hand',
+        dispose: 'disposed',
+        renew: 'refurbished',
+        return: 'returned to manufacturer',
+      },
+    },
+    app: {
+      title: 'Service Manager',
+      subtitle: 'Jobs • Inventory • Reports',
+      tabs: { jobs: 'Jobs', inventory: 'Inventory', reports: 'Report' },
+      footerNotice: 'Data is stored locally in your browser. Import/Export = copy/migrate.',
+      languageToggle: {
+        button: 'PL / EN',
+        aria: 'Switch language to {{language}}',
+      },
+    },
+    emptyState: {
+      title: 'Start by adding a company',
+      description: 'The app is ready to go. Add a company, then create jobs and manage inventory.',
+      loadDemo: 'Load demo data',
+    },
+    companySwitcher: {
+      button: 'Companies ▾',
+      manage: 'Manage',
+      nameLabel: 'Company name',
+      placeholder: 'e.g. ACME Ltd.',
+      add: 'Add',
+      removeCurrent: 'Remove current',
+      confirmDelete: 'Remove the current company? This will delete its data!',
+    },
+    importExport: {
+      import: 'Import',
+      export: 'Export',
+      importSuccess: 'Data imported',
+      invalidFile: 'Invalid file',
+      importError: 'Import failed: {{error}}',
+      fileNamePrefix: 'service-manager-backup',
+    },
+    jobs: {
+      titleNew: 'New job',
+      titleEdit: 'Edit job',
+      form: {
+        orderNumberLabel: 'Job number *',
+        orderNumberPlaceholder: 'e.g. JOB-2025-001',
+        serialLabel: 'Device serial number',
+        serialPlaceholder: 'e.g. SN123456',
+        issueLabel: 'Issue description',
+        issuePlaceholder: 'What is happening with the device?',
+        incomingTrackingLabel: 'Tracking (incoming)',
+        outgoingTrackingLabel: 'Tracking (outgoing)',
+        trackingPlaceholder: 'URL or tracking number',
+        actionsLabel: 'Actions performed',
+        actionsPlaceholder: 'What was done?',
+        statusLabel: 'Status',
+        typeLabel: 'Job type',
+        dueDateLabel: 'Due date (SLA)',
+        shipmentsTitle: 'Shipping and insurance costs (PLN)',
+        shipmentsInCaption: 'INBOUND (IN)',
+        shipmentsOutCaption: 'OUTBOUND (OUT)',
+        shipInLabel: 'Shipping cost (IN)',
+        shipOutLabel: 'Shipping cost (OUT)',
+        insuranceInLabel: 'Insurance (IN)',
+        insuranceOutLabel: 'Insurance (OUT)',
+        shipPlaceholder: 'e.g. 85.00',
+        insurancePlaceholder: 'e.g. 12.00',
+        openLink: 'Open',
+        saveButton: 'Save changes',
+        addButton: 'Add job',
+        cancelButton: 'Cancel',
+      },
+      filters: {
+        searchPlaceholder: 'Search (number, SN, description...)',
+        statusAll: 'All statuses',
+        typeAll: 'All types',
+      },
+      list: {
+        title: 'Jobs list',
+        columns: {
+          number: 'Number',
+          serial: 'SN',
+          type: 'Type',
+          sla: 'SLA',
+          status: 'Status',
+          createdAt: 'Created',
+          actions: 'Actions',
+        },
+        actionEdit: 'Edit',
+        actionParts: 'Parts',
+        actionDelete: 'Delete',
+        empty: 'No jobs match the filters',
+      },
+      details: {
+        serial: 'SN:',
+        issue: 'Issue:',
+        actions: 'Actions:',
+        type: 'Type:',
+        sla: 'Due date (SLA):',
+        trackingIn: 'Tracking IN:',
+        trackingOut: 'Tracking OUT:',
+        updatedAt: 'Last updated:',
+        shipmentCosts: 'Shipping costs:',
+        inboundLabel: 'IN',
+        outboundLabel: 'OUT',
+        insuranceShort: 'Ins.',
+        usageTitle: 'Parts used:',
+        noUsage: 'None',
+        dispositionPrefix: 'outcome: {{label}}',
+        quantityWithUnit: '{{qty}} pcs',
+      },
+      usageModal: {
+        title: 'Parts usage',
+        selectorLabel: 'Inventory item',
+        selectorPlaceholder: '— select —',
+        quantityLabel: 'Quantity',
+        dispositionLabel: 'Part outcome',
+        addButton: 'Add',
+        tableHeaders: {
+          name: 'Name',
+          sku: 'SKU',
+          qty: 'Qty',
+          disposition: 'Outcome',
+          actions: '',
+        },
+        empty: 'Nothing added',
+        remove: 'Remove',
+        apply: 'Save and update inventory',
+        cancel: 'Cancel',
+        inventoryOption: '{{name}} (SKU: {{sku}}) — available: {{qty}}',
+      },
+      alerts: {
+        orderNumberRequired: 'Provide a job number',
+      },
+      confirm: {
+        delete: 'Delete this job?',
+      },
+    },
+    inventory: {
+      formTitle: 'Add item',
+      nameLabel: 'Name *',
+      namePlaceholder: 'e.g. Module A / Capacitor 100uF',
+      skuLabel: 'SKU / index',
+      skuPlaceholder: 'e.g. CAP-100',
+      qtyLabel: 'Initial quantity',
+      locationLabel: 'Location',
+      locationPlaceholder: 'e.g. Shelf A3',
+      minQtyLabel: 'Minimum stock',
+      addButton: 'Add to inventory',
+      searchPlaceholder: 'Search inventory',
+      tableTitle: 'Inventory levels',
+      columns: {
+        name: 'Name',
+        sku: 'SKU',
+        location: 'Location',
+        qty: 'Stock',
+        min: 'Min',
+        actions: 'Actions',
+      },
+      lowStockBadge: 'Low stock',
+      empty: 'Inventory is empty',
+      increment: '+1',
+      decrement: '-1',
+      remove: 'Delete',
+      alerts: {
+        nameRequired: 'Provide an item name',
+      },
+      confirm: {
+        delete: 'Remove this inventory item?',
+      },
+    },
+    repairQueue: {
+      title: 'Repair queue',
+      columns: {
+        date: 'Date',
+        job: 'Job',
+        part: 'Part',
+        sku: 'SKU',
+        qty: 'Qty',
+        disposition: 'Outcome',
+        actions: 'Actions',
+      },
+      empty: 'Queue is empty',
+      actions: {
+        ok: 'OK',
+        bad: 'BAD',
+        return: 'Returned',
+      },
+    },
+    reports: {
+      dateRangeTitle: 'Date range',
+      fromLabel: 'From',
+      toLabel: 'To',
+      jobsSummaryTitle: 'Job summary',
+      jobsSummary: {
+        totalPrefix: 'Total (within range):',
+      },
+      partsSummaryTitle: 'Parts summary',
+      partsSummary: {
+        totalPrefix: 'Parts used (qty):',
+        keptLabel: 'Kept on hand',
+        disposedLabel: 'Disposed',
+        disposalEventsLabel: 'Disposal events',
+        returnEventsLabel: 'Returns to manufacturer',
+        renewEventsLabel: 'Refurbishments (entries)',
+      },
+      shipmentsTitle: 'Shipping costs (PLN)',
+      shipments: {
+        shipmentLabel: 'Shipping',
+        insuranceLabel: 'Insurance',
+        totalLabel: 'Total:',
+      },
+      modal: {
+        noResults: 'No results',
+        close: 'Close',
+        jobsTitle: 'Jobs — {{label}}',
+        partsTitle: 'Parts — {{label}}',
+        jobStatusPrefix: 'Status: {{status}}',
+        jobTypePrefix: 'Type: {{type}}',
+        jobCreatedAt: 'Created: {{date}}',
+        jobFallbackTitle: 'Job {{id}}',
+        partQty: 'Quantity: {{qty}}',
+        partDisposition: 'Outcome: {{label}}',
+        partJob: 'Job: {{job}}',
+        partDate: 'Date: {{date}}',
+        partUnknown: 'Unknown part',
+        jobNoStatus: 'No status',
+        jobNoDate: 'No date',
+      },
+    },
+    demo: {
+      companies: {
+        first: 'Company A',
+        second: 'Company B',
+      },
+      jobs: {
+        first: {
+          orderNumber: 'ZL-2025-001',
+          serialNumber: 'SN12345',
+          issue: 'Does not power on',
+          actions: 'Power diagnostics',
+        },
+        second: {
+          orderNumber: 'ZL-2025-002',
+          serialNumber: 'SN55555',
+          issue: 'No video output',
+          actions: 'Capacitor replacement',
+        },
+      },
+      inventory: {
+        capacitor: 'Capacitor 100uF',
+        psu: '12V power supply',
+      },
+    },
+  },
+}
+
+export function getStoredLanguage(){
+  if (typeof window === 'undefined') return DEFAULT_LANGUAGE
+  try {
+    const stored = window.localStorage.getItem(LANGUAGE_STORAGE_KEY)
+    if (stored && translations[stored]) return stored
+  } catch {}
+  return DEFAULT_LANGUAGE
+}
+
+function getTranslationObject(lang){
+  return translations[lang] || translations[DEFAULT_LANGUAGE]
+}
+
+export function translate(lang, key, replacements = {}){
+  const source = getTranslationObject(lang)
+  const parts = key.split('.').filter(Boolean)
+  let current = source
+  for (const part of parts){
+    if (current && Object.prototype.hasOwnProperty.call(current, part)){
+      current = current[part]
+    } else {
+      current = null
+      break
+    }
+  }
+  if (current == null) return key
+  if (typeof current !== 'string') return current
+  let result = current
+  for (const [token, value] of Object.entries(replacements)){
+    result = result.replaceAll(`{{${token}}}`, String(value))
+  }
+  return result
+}
+
+const LanguageContext = createContext({
+  lang: DEFAULT_LANGUAGE,
+  locale: getTranslationObject(DEFAULT_LANGUAGE).meta.locale,
+  currency: getTranslationObject(DEFAULT_LANGUAGE).meta.currency,
+  setLanguage: () => {},
+  toggleLanguage: () => {},
+  t: (key, replacements) => translate(DEFAULT_LANGUAGE, key, replacements),
+  formatCurrency: (value) => String(value ?? ''),
+  formatDate: (value) => value ? new Date(value).toLocaleDateString(getTranslationObject(DEFAULT_LANGUAGE).meta.locale) : '',
+  formatDateTime: (value) => value ? new Date(value).toLocaleString(getTranslationObject(DEFAULT_LANGUAGE).meta.locale) : '',
+})
+
+export function LanguageProvider({ children }){
+  const [lang, setLang] = useState(() => getStoredLanguage())
+
+  useEffect(() => {
+    if (typeof document !== 'undefined'){
+      document.documentElement.lang = lang
+    }
+    try {
+      if (typeof window !== 'undefined'){
+        window.localStorage.setItem(LANGUAGE_STORAGE_KEY, lang)
+      }
+    } catch {}
+  }, [lang])
+
+  const setLanguage = useCallback((next) => {
+    setLang(prev => {
+      if (!next || !translations[next]) return prev
+      return next
+    })
+  }, [])
+
+  const toggleLanguage = useCallback(() => {
+    setLang(prev => (prev === 'pl' ? 'en' : 'pl'))
+  }, [])
+
+  const locale = getTranslationObject(lang).meta.locale || 'pl-PL'
+  const currency = getTranslationObject(lang).meta.currency || 'PLN'
+
+  const t = useCallback((key, replacements) => translate(lang, key, replacements), [lang])
+
+  const currencyFormatter = useMemo(
+    () => new Intl.NumberFormat(locale, { style: 'currency', currency }),
+    [locale, currency]
+  )
+
+  const formatCurrency = useCallback((value, options = {}) => {
+    const number = Number(value || 0)
+    const targetLocale = options.locale || locale
+    const targetCurrency = options.currency || currency
+    if (options.locale || options.currency){
+      return new Intl.NumberFormat(targetLocale, { style: 'currency', currency: targetCurrency }).format(number)
+    }
+    return currencyFormatter.format(number)
+  }, [currencyFormatter, locale, currency])
+
+  const formatDate = useCallback((value, options = {}) => {
+    if (!value) return ''
+    const date = value instanceof Date ? value : new Date(value)
+    return date.toLocaleDateString(options.locale || locale, options)
+  }, [locale])
+
+  const formatDateTime = useCallback((value, options = {}) => {
+    if (!value) return ''
+    const date = value instanceof Date ? value : new Date(value)
+    return date.toLocaleString(options.locale || locale, options)
+  }, [locale])
+
+  const contextValue = useMemo(() => ({
+    lang,
+    locale,
+    currency,
+    setLanguage,
+    toggleLanguage,
+    t,
+    formatCurrency,
+    formatDate,
+    formatDateTime,
+  }), [lang, locale, currency, setLanguage, toggleLanguage, t, formatCurrency, formatDate, formatDateTime])
+
+  return (
+    <LanguageContext.Provider value={contextValue}>
+      {children}
+    </LanguageContext.Provider>
+  )
+}
+
+export function useLanguage(){
+  return useContext(LanguageContext)
+}
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,11 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
+import { LanguageProvider } from './i18n.jsx'
 import './styles.css'
 
-createRoot(document.getElementById('root')).render(<App />)
+createRoot(document.getElementById('root')).render(
+  <LanguageProvider>
+    <App />
+  </LanguageProvider>
+)


### PR DESCRIPTION
## Summary
- add an i18n module with Polish and English translations, locale-aware formatters, and persisted language state
- wrap the application in the LanguageProvider and expose a header language toggle that updates empty-state messaging
- translate company management, import/export, jobs, inventory, repair queue, reports, and utility helpers so demo data and labels follow the active language

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9e370bf20832f8202a8ebf74bf009